### PR TITLE
Added YCode conversion

### DIFF
--- a/src/binary/Y2YCPTypeConv.cc
+++ b/src/binary/Y2YCPTypeConv.cc
@@ -208,7 +208,15 @@ ycpvalue_2_rbvalue( YCPValue ycpval )
       return ycp_ext_to_rb_ext(ex);
     }
   }
-  rb_raise( rb_eTypeError, "Conversion of YCP type %s not supported", ycpval->toString().c_str() );
+  else if (ycpval->isCode())
+  {
+    y2debug("Evaluating YCP code: %s", ycpval->toString().c_str());
+    YCPValue val = ycpval->asCode()->evaluate();
+    y2debug("Evaluated code returned: %s", val->toString().c_str() );
+
+    return ycpvalue_2_rbvalue(val);
+  }
+  rb_raise( rb_eTypeError, "Conversion of YCP type '%s': %s not supported", Type::vt2type(ycpval->valuetype())->toString().c_str(), ycpval->toString().c_str() );
   return Qnil;
 }
 


### PR DESCRIPTION
evaluate the code and return the result

needed for converting e.g. `SCR::Read(.target.yast2, "languages/language_cs_CZ.ycp")` results
- for unknown types put also the type to the exception message
