### PR TITLE
Added lsort() builtin

### DIFF
--- a/src/binary/Builtin.cc
+++ b/src/binary/Builtin.cc
@@ -603,6 +603,16 @@ extern "C" {
     return list;
   }
 
+  // a wrapper around glibc strcoll() function,
+  // needed for sorting using the current locale
+  static VALUE
+  strcoll_wrapper(VALUE self, VALUE str1, VALUE str2)
+  {
+    Check_Type(str1, T_STRING);
+    Check_Type(str2, T_STRING);
+
+    return INT2FIX(strcoll(RSTRING_PTR(str1), RSTRING_PTR(str2)));
+  }
 
 }
 
@@ -621,6 +631,7 @@ extern "C"
      * module YCP
      */
     rb_mYCP = rb_define_module("YCP");
+    rb_define_singleton_method( rb_mYCP, "strcoll", RUBY_METHOD_FUNC(strcoll_wrapper), 2);
     rb_mSCR = rb_define_module_under(rb_mYCP, "SCR");
     rb_define_singleton_method( rb_mSCR, "call_builtin", RUBY_METHOD_FUNC(scr_call_builtin), -1);
     rb_mWFM = rb_define_module_under(rb_mYCP, "WFM");

--- a/src/ruby/ycp/builtins.rb
+++ b/src/ruby/ycp/builtins.rb
@@ -368,8 +368,13 @@ module YCP
     end
 
     # Sort A List respecting locale
-    def self.lsort
-      raise "Builtin lsort() is not implemented yet"
+    def self.lsort list
+      return nil if list.nil?
+
+      # TODO FIXME: not 100% YCP compatible for non string values
+      # YCP: lsort(["a", 50, "z", true]) -> [true, 50, "a", "z"]
+      # this code:                       -> [50, "a", true, "z"]
+      list.sort { |s1, s2| YCP.strcoll s1.to_s, s2.to_s }
     end
 
     # merge() YCP built-in

--- a/tests/ruby/builtins_test.rb
+++ b/tests/ruby/builtins_test.rb
@@ -808,4 +808,11 @@ class BuiltinsTest < YCP::TestCase
       assert (res.size>10), "res too small #{res} for crypt#{suffix}"
     end
   end
+
+  def test_lsort
+    assert_equal ["a", "b", "c"], YCP::Builtins.lsort(["c", "b", "a"])
+    assert_equal [1, 2, 3], YCP::Builtins.lsort([3, 2, 1])
+    assert_equal [1, 2, 3, "a", "b"], YCP::Builtins.lsort([3, "a", 2, "b", 1])
+  end
+
 end


### PR DESCRIPTION
Defines `YCP.strcoll` wrapper around `strcoll()` glibc function which is used in builtin implementation.

It's not 100% YCP compatible (regarding to non-string values), but should be good enough for now. I checked YaST sources and it seems to be used just with strings as expected.
