### PR TITLE
Use "external" encoding (set by locale, usually UTF-8) for YCP strings

### DIFF
--- a/src/binary/Y2YCPTypeConv.cc
+++ b/src/binary/Y2YCPTypeConv.cc
@@ -145,7 +145,8 @@ ycpvalue_2_rbvalue( YCPValue ycpval )
   }
   else if (ycpval->isString())
   {
-    return rb_str_new2(ycpval->asString()->value().c_str());
+    // use "external" encoding (set by locale, usually UTF-8)
+    return rb_external_str_new(ycpval->asString()->value().c_str(), ycpval->asString()->value().size());
   }
   else if (ycpval->isPath())
   {

--- a/src/binary/YRuby.cc
+++ b/src/binary/YRuby.cc
@@ -25,6 +25,7 @@ as published by the Free Software Foundation; either version
 #include <iosfwd>
 #include <sstream>
 #include <iomanip>
+#include <locale.h>
 
 // Ruby stuff
 #include <ruby.h>
@@ -55,6 +56,10 @@ bool YRuby::_y_ruby_finalized = false;
 YRuby::YRuby()
 {
   y2debug( "Initializing ruby interpreter." );
+
+  // initialize locale according to the language setting
+  // so the ruby interpreter can set the external string encoding properly
+  setlocale (LC_ALL, "");
 
   RUBY_INIT_STACK;
   ruby_init();


### PR DESCRIPTION
...instead of ASCII-8BIT default which can lead to error "incompatible character encodings: ASCII-8BIT and UTF-8" when merging Ruby and YCP strings
