### PR TITLE
Use the correct call frame when setting the ExecutionEnvironment. (#23)

### DIFF
--- a/src/ruby/ycp/scr.rb
+++ b/src/ruby/ycp/scr.rb
@@ -44,7 +44,7 @@ module YCP
 
     # FIXME duplicate of code in wfm
     def self.call_builtin_wrapper *args
-      from = caller[2]
+      from = caller[1]          # caller[0] is one of the functions above
       filename = from[/^[^:]+/]
       lineno = from[/:\d+/][1..-1].to_i
       call_builtin(filename,lineno,*args)

--- a/src/ruby/ycp/wfm.rb
+++ b/src/ruby/ycp/wfm.rb
@@ -70,7 +70,7 @@ module YCP
     end
 
     def self.call_builtin_wrapper *args
-      from = caller[2]
+      from = caller[1]          # caller[0] is one of the functions above
       filename = from[/^[^:]+/]
       lineno = from[/:\d+/][1..-1].to_i
       call_builtin(filename,lineno,*args)


### PR DESCRIPTION
https://github.com/yast/yast-ruby-bindings/issues/23
