### PR TITLE
Fixed YCP compatibility in Builtins.tointeger()

### DIFF
--- a/src/ruby/ycp/builtins.rb
+++ b/src/ruby/ycp/builtins.rb
@@ -1,4 +1,5 @@
 require "set"
+require "scanf"
 
 require "ycp/ycp"
 require "ycp/path"
@@ -297,8 +298,16 @@ module YCP
       return nil if object.nil?
 
       case object
+      when ::String
+        # ideally this should be enought: object.scanf("%i").first
+        # but to be 100% YCP compatible we need to do this,
+        # see https://github.com/yast/yast-core/blob/master/libycp/src/YCPInteger.cc#L39
+        if object[0] == "0"
+          return object.scanf((object[1] == "x") ? "%x" : "%o").first
+        end
+        object.scanf("%d").first
       # use full qualified ::Float to avoid clash with YCP::Builtins::Float
-      when ::String, ::Float, ::Fixnum, ::Bignum
+      when ::Float, ::Fixnum, ::Bignum
         object.to_i
       else
         nil

--- a/tests/ruby/builtins_test.rb
+++ b/tests/ruby/builtins_test.rb
@@ -347,9 +347,24 @@ class BuiltinsTest < YCP::TestCase
 
   def test_tointeger()
     assert_equal nil, YCP::Builtins.tointeger(nil)
+    assert_equal nil, YCP::Builtins.tointeger("")
+    assert_equal nil, YCP::Builtins.tointeger("foo")
     assert_equal 120, YCP::Builtins.tointeger(120)
     assert_equal 120, YCP::Builtins.tointeger("120")
+    assert_equal 120, YCP::Builtins.tointeger("  120asdf")
     assert_equal 120, YCP::Builtins.tointeger(120.0)
+    assert_equal 32, YCP::Builtins.tointeger("0x20")
+    assert_equal 0, YCP::Builtins.tointeger(" 0x20")
+    assert_equal 32, YCP::Builtins.tointeger("0x20Z")
+    assert_equal 8, YCP::Builtins.tointeger("010")
+    assert_equal -10, YCP::Builtins.tointeger("-10")
+
+    # weird YCP cases
+    assert_equal 0, YCP::Builtins.tointeger("-0x20")
+    assert_equal 0, YCP::Builtins.tointeger(" 0x20")
+    assert_equal 20, YCP::Builtins.tointeger(" 020")
+    assert_equal -20, YCP::Builtins.tointeger("-020")
+    assert_equal -20, YCP::Builtins.tointeger("-0020")
   end
 
   def test_search


### PR DESCRIPTION
Builtins `tointeger("")` or `tointeger("foo")` should return `nil`, Ruby returns `0`

this makes passing the testsuite in country correctly
