### PR TITLE
Fixed regexp in include method construction

### DIFF
--- a/src/ruby/yast/yast.rb
+++ b/src/ruby/yast/yast.rb
@@ -72,7 +72,7 @@ module Yast
 
     target.class.send(:include, mod)
 
-    method_name = "initialize_" + path_without_suffix.gsub(/[.-\/]/, "_")
+    method_name = "initialize_" + path_without_suffix.gsub(/[-.\/]/, "_")
 
     target.send method_name.to_sym, target
   end


### PR DESCRIPTION
The `-` must be at the beginning otherwise it means a range which is wrong in this case.
