### PR TITLE
remove autoconversion, does not work in all cases properly

### DIFF
--- a/src/ruby/yast/ops.rb
+++ b/src/ruby/yast/ops.rb
@@ -1,7 +1,6 @@
 require "yast/yast"
 require "yast/path"
 require "yast/logger"
-require "yast/convert"
 
 #predefine term to avoid circular dependency
 class Yast::Term;end
@@ -68,25 +67,6 @@ module Yast
             return block_given? ? yield : default
           end
       end
-
-      #included automatic conversion based on type of default
-      unless default.nil? #nil is any, but false is boolean
-        target_type = ""
-        TYPES_MAP.each_pair do |k,v|
-          values = v.is_a?(::Array) ? v : [v]
-          if values.any? { |val| val == default.class }
-            target_type = k
-            break
-          end
-        end
-
-        if target_type.empty?
-          Yast.y2internal "wrong type '#{default.class}' for index"
-        else
-          res = Convert.convert(res, :from => "any", :to => target_type)
-        end
-      end
-
       return Yast.deep_copy(res)
     end
 

--- a/tests/ruby/ops_test.rb
+++ b/tests/ruby/ops_test.rb
@@ -164,7 +164,7 @@ class Yast::OpsTest < Yast::TestCase
 
   def test_index_map
     map = { "a" => { "b" => "c" }}
-    assert_equal({ "b" => "c"}, Yast::Ops.index(map,"a",{}))
+    assert_equal({ "b" => "c"}, Yast::Ops.index(map,"a","n"))
     assert_equal "c", Yast::Ops.index(map,["a","b"],"n")
     assert_equal "n", Yast::Ops.index(map,["a","c"],"n")
     assert_equal "n", Yast::Ops.index(map,["c","b"],"n")
@@ -173,7 +173,7 @@ class Yast::OpsTest < Yast::TestCase
 
   def test_index_list
     list = [["a","b"]]
-    assert_equal(["a","b"], Yast::Ops.index(list,0,[]))
+    assert_equal(["a","b"], Yast::Ops.index(list,0,"n"))
     assert_equal "b", Yast::Ops.index(list,[0,1],"n")
     assert_equal "n", Yast::Ops.index(list,[0,2],"n")
     assert_equal "n", Yast::Ops.index(list,[1,1],"n")
@@ -196,10 +196,8 @@ class Yast::OpsTest < Yast::TestCase
 
   def test_index_corner_cases
     list = ["a"]
-     assert_equal "n", Yast::Ops.index(list,["a"],"n")
-     assert_equal "n", Yast::Ops.index(list,[0,0],"n")
-     assert_equal 1, Yast::Ops.index([1.0],0,0)
-    assert_equal nil, Yast::Ops.index([1.0],0,"")
+    assert_equal "n", Yast::Ops.index(list,["a"],"n")
+    assert_equal "n", Yast::Ops.index(list,[0,0],"n")
   end
 
   def test_assign


### PR DESCRIPTION
partly reverts commit c0243b9d2832535ac12bbd72f80d9150f256f8a8

autoconversion breaks tests, there is used list<any> with $[](hash)
default value, when passing list<list> (e.g. [[map1, map2]]) then the conversion
fails as the index result is list not hash (as guessed from the type of the default)

(see Testsuite::Init() in Testsuite.ycp)
