### PR TITLE
Implement Ops.get_* shortcut methods

### DIFF
--- a/src/ruby/yast/convert.rb
+++ b/src/ruby/yast/convert.rb
@@ -7,8 +7,7 @@ module Yast
   module Convert
 
     #generate shortcuts
-    [ "boolean", "string", "symbol", "integer", "float", "list", "map", 
-      "term", "path", "locale" ].each do |type|
+    Ops::SHORTCUT_TYPES.each do |type|
       eval <<END
         def self.to_#{type}(object)
           convert object, :from => "any", :to => "#{type}"

--- a/src/ruby/yast/ops.rb
+++ b/src/ruby/yast/ops.rb
@@ -29,6 +29,28 @@ module Yast
       'byteblock' => Yast::Byteblock
     }
 
+    # Types for which we generate shortcut methods, e.g. Ops.get_string or
+    # Convert.to_string.
+    SHORTCUT_TYPES = [
+      "boolean",
+      "string",
+      "symbol",
+      "integer",
+      "float",
+      "list",
+      "map",
+      "term",
+      "path",
+      "locale"
+    ]
+
+    Ops::SHORTCUT_TYPES.each do |type|
+      eval <<END
+        def self.get_#{type}(*args, &block)
+          Yast::Convert.to_#{type} get(*args, &block)
+        end
+END
+    end
 
       def self.index (*args, &block)
         get *args, &block

--- a/tests/ruby/ops_test.rb
+++ b/tests/ruby/ops_test.rb
@@ -4,6 +4,7 @@ $LOAD_PATH << File.dirname(__FILE__)
 require "test_helper"
 
 require "yast/ops"
+require "yast/convert"
 require "yast/path"
 require "yast/term"
 
@@ -198,6 +199,12 @@ class Yast::OpsTest < Yast::TestCase
     list = ["a"]
     assert_equal "n", Yast::Ops.index(list,["a"],"n")
     assert_equal "n", Yast::Ops.index(list,[0,0],"n")
+  end
+
+  def test_get_shortcuts
+    list = ["a","b"]
+    assert_equal("a", Yast::Ops.get_string(list,0,"n"))
+    assert_equal(nil, Yast::Ops.get_integer(list,0,"n"))
   end
 
   def test_assign


### PR DESCRIPTION
In code geenreated by Y2R, we often have pieces like this:

  Convert.to_string(Ops.get(l, 0, "foo"))

This code is typically emitted because the original collection is
untyped.

Because this pattern appears over and over, we decided to simplify it to
something like this:

  Ops.get_string(l, 0, "foo"))

That is, introduce and use shortcut methods that would combine getting
an item from a collection with type conversion.

This commit adds needed shortcut methods to Ruby bindings. It will be
followed by a commit in Y2R that will generate code which will use them.
