### PR TITLE
Builtins.y2milestone(),... marked as deprecated

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb  5 14:20:37 UTC 2014 - lslezak@suse.cz
+
+- Builtins.y2milestone(),... marked as deprecated, use Yast::Logger
+  instead in the new code
+- 3.1.8
+
+-------------------------------------------------------------------
 Tue Feb  4 14:34:15 UTC 2014 - jreidinger@suse.com
 
 - format spec file

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.7
+Version:        3.1.8
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        yast2-ruby-bindings-%{version}.tar.bz2

--- a/src/ruby/yast/builtins.rb
+++ b/src/ruby/yast/builtins.rb
@@ -15,6 +15,9 @@ module Yast
   class FunRef; end
 
   # Contains builtins available in YCP for easier transition. Big part of methods are deprecated.
+  #
+  # For logging use {Yast::Logger} module instead of deprecated {Builtins.y2milestone},... functions
+  #
   # @note All builtins return copy of result
   module Builtins
 
@@ -604,36 +607,42 @@ module Yast
     end
 
     # Log a message to the y2log.
+    # @deprecated Use {Yast::Logger} instead
     def self.y2debug *args
       shift_frame_number args
       Yast.y2debug *args
     end
 
     # Log an error to the y2log.
+    # @deprecated Use {Yast::Logger} instead
     def self.y2error *args
       shift_frame_number args
       Yast.y2error *args
     end
 
     # Log an internal message to the y2log.
+    # @deprecated Use {Yast::Logger} instead
     def self.y2internal *args
       shift_frame_number args
       Yast.y2internal *args
     end
 
     # Log a milestone to the y2log.
+    # @deprecated Use {Yast::Logger} instead
     def self.y2milestone*args
       shift_frame_number args
       Yast.y2milestone *args
     end
 
     # Log a security message to the y2log.
+    # @deprecated Use {Yast::Logger} instead
     def self.y2security *args
       shift_frame_number args
       Yast.y2security *args
     end
 
     # Log a warning to the y2log.
+    # @deprecated Use {Yast::Logger} instead
     def self.y2warning *args
       shift_frame_number args
       Yast.y2warning *args
@@ -643,7 +652,7 @@ module Yast
     def self.shift_frame_number args
       if args.first.is_a? ::Fixnum
         args[0] += 1 if args[0] >= 0
-      else 
+      else
         args.unshift 1
       end
     end

--- a/src/ruby/yast/y2logger.rb
+++ b/src/ruby/yast/y2logger.rb
@@ -45,16 +45,26 @@ module Yast
 
   # This module provides access to Yast specific logging
   #
-  # @example Use YastLogger in an easy way
-  #   class Foo
-  #     include Yast::Logger
+  # @example Yast::Logger example
+  #    module Yast
+  #      class Foo < Client
+  #        include Yast::Logger
   #
-  #     def foo
-  #       # this will be logged into y2log using the usual y2log format
-  #       log.debug "debug"
-  #       log.error "error"
-  #     end
-  #   end
+  #        def foo
+  #          # this will be logged into y2log using the usual y2log format
+  #
+  #          # Builtins.y2debug() replacement
+  #          log.debug "debug"
+  #
+  #          # Builtins.y2milestone() replacement
+  #          log.info "info"
+  #
+  #          # Builtins.y2error() replacement
+  #          log.error "error"
+  #        end
+  #      end
+  #    end
+  #
   module Logger
     def log
       Y2Logger.instance


### PR DESCRIPTION
- use `Yast::Logger` instead in the new code
- 3.1.8
