### PR TITLE
added N_() and Nn_() gettext equivalents

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Feb 26 12:22:48 UTC 2014 - lslezak@suse.cz
+
+- added N_() and Nn_() gettext equivalents (to only mark a text
+  for translation)
+- 3.1.12
+
+-------------------------------------------------------------------
 Thu Feb 20 07:58:32 UTC 2014 - jreidinger@suse.com
 
 - always log full backtrace when type conversion failed, to help

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.11
+Version:        3.1.12
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        yast2-ruby-bindings-%{version}.tar.bz2

--- a/src/ruby/yast/i18n.rb
+++ b/src/ruby/yast/i18n.rb
@@ -48,6 +48,18 @@ module Yast
       FastGettext.text_domain = old_text_domain
     end
 
+    # No translation, only marks the text to be found by gettext when creating POT file,
+    # the text needs to be translated by _() later.
+    def N_(str)
+      str
+    end
+
+    # No translation, only marks the texts to be found by gettext when creating POT file,
+    # the texts need to be translated by n_() later.
+    def Nn_(*keys)
+      keys
+    end
+
     # Gets translation based on number.
     # @param (String) singular text for translators for single value
     # @param (String) plural text for translators for bigger value

--- a/tests/ruby/i18n_spec.rb
+++ b/tests/ruby/i18n_spec.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper_rspec"
+
+require "yast"
+
+include Yast::I18n
+
+module Yast
+  describe I18n do
+
+    describe ".N_" do
+      it "returns the original parameter" do
+        input = "INPUT TEST"
+        expect(N_(input)).to be input
+      end
+    end
+
+    describe ".Nn_" do
+      it "returns the original parameters" do
+        singular = "singular"
+        plural = "plural"
+        count = 42
+
+        expect(Nn_(singular, plural, count)).to eq [singular, plural, count]
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
- to only mark a text for translation
- 3.1.12
