### PR TITLE
logger - remove invalid UTF-8 characters to avoid crash (bnc#876459)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed May 28 15:20:10 UTC 2014 - lslezak@suse.cz
+
+- logger - remove invalid UTF-8 characters to avoid crash
+  (bnc#876459)
+- 3.1.18
+
+-------------------------------------------------------------------
 Wed May 14 13:13:09 UTC 2014 - mvidner@suse.com
 
 - Mechanically converted the remaining test/unit tests to RSpec

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.17
+Version:        3.1.18
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
 Source0:        yast2-ruby-bindings-%{version}.tar.bz2

--- a/src/ruby/yast/logger.rb
+++ b/src/ruby/yast/logger.rb
@@ -20,6 +20,12 @@ module Yast
     end
 
     res = Builtins.sformat(*args)
+
+    # replace invalid UTF-8 characters by "?", UTF-16 step is needed to force
+    # the re-encoding (it would skip recoding for string already in UTF-8)
+    res.encode!('UTF-16', :undef => :replace, :invalid => :replace, :replace => "?")
+    res.encode!('UTF-8')
+
     res.gsub!(/%/,"%%") #reescape all %
     caller[caller_frame] =~ /(.+):(\d+):in `([^']+)'/
     y2_logger(level, "Ruby", $1, $2.to_i, "", res)


### PR DESCRIPTION
- 3.1.18
