### PR TITLE
use old rubygem dependency style on 13.1

### DIFF
--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -28,11 +28,16 @@ BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 3.1.10
-# libzypp-devel is missing .la requires
-BuildRequires:  ruby-devel
+%if 0%{suse_version} == 1310
+BuildRequires:  rubygem-fast_gettext
+BuildRequires:  rubygem-rspec
+Requires:       rubygem-fast_gettext
+%else
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:fast_gettext)
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 Requires:       rubygem(%{rb_default_ruby_abi}:fast_gettext)
+%endif
+BuildRequires:  ruby-devel
 Requires:       yast2-core >= 2.24.0
 BuildRequires:  yast2-core-devel >= 2.24.0
 Requires:       yast2-ycp-ui-bindings       >= 2.21.9


### PR DESCRIPTION
fixes build at YaST:Head for 13.1
