### PR TITLE
Fix building with yast2-core-3.1.16: use C++11 like core does

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,8 +10,8 @@ endif()
 
 project(yast2-ruby-bindings)
 set(PACKAGE "yast2-ruby-bindings")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -g -O3 -Wall -Woverloaded-virtual")
-set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -g -O3 -Wall")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=gnu++0x -g -O3 -Wall -Woverloaded-virtual")
+set(CMAKE_C_FLAGS   "${CMAKE_C_FLAGS}   -std=gnu++0x -g -O3 -Wall")
 
 #
 # Where is YaST ?

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  5 15:15:07 UTC 2015 - mvidner@suse.com
+
+- Fix building with yast2-core-3.1.16: use C++11 like core does
+  (boo#914255).
+- 3.1.30
+
+-------------------------------------------------------------------
 Tue Feb 24 17:55:42 UTC 2015 - jreidinger@suse.com
 
 - fix building for ruby2.2

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.29
+Version:        3.1.30
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
https://bugzilla.novell.com/show_bug.cgi?id=914255