### PR TITLE
Fixed "Comparable#== will no more rescue exceptions of #<=>" (bsc#933470)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun  3 13:01:29 UTC 2015 - mvidner@suse.com
+
+- Fixed "Comparable#== will no more rescue exceptions of #<=>"
+  (boo#933470).
+- Fixed a strdup/delete mismatch (boo#932306).
+- 3.1.34
+
+-------------------------------------------------------------------
 Mon May 25 10:00:40 UTC 2015 - jreidinger@suse.com
 
 - add ability to test if scr is local (FATE#317900)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.33
+Version:        3.1.34
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/path.rb
+++ b/src/ruby/yast/path.rb
@@ -43,6 +43,7 @@ module Yast
     end
 
     def <=>(other)
+      return nil unless other.is_a? self.class
       0.upto(size-1) do |i|
         return 1 unless other.send(:components)[i]
         #we strip enclosing quotes for complex expression

--- a/src/ruby/yast/term.rb
+++ b/src/ruby/yast/term.rb
@@ -88,6 +88,7 @@ module Yast
     end
 
     def <=> (other)
+      return nil unless other.is_a? self.class
       res = value <=> other.value
       return res if res != 0
 

--- a/tests/ruby/ops_spec.rb
+++ b/tests/ruby/ops_spec.rb
@@ -163,14 +163,14 @@ describe "Yast::OpsTest" do
     end
 
     context "when the container is a term" do
-      let(:term) { Yast::Term.new(:a,"a","b") }
+      let(:aterm) { Yast::Term.new(:a,"a","b") }
 
       it "returns value if key exists" do
-        expect(Yast::Ops.get(term,1,"n")).to eq("b")
+        expect(Yast::Ops.get(aterm,1,"n")).to eq("b")
       end
 
       it "returns default if FIXME" do
-        expect(Yast::Ops.get(term,[2],"n")).to eq("n")
+        expect(Yast::Ops.get(aterm,[2],"n")).to eq("n")
       end
     end
 

--- a/tests/ruby/path_spec.rb
+++ b/tests/ruby/path_spec.rb
@@ -1,49 +1,59 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# FIXME: this file was autoconverted from test/unit syntax without
-# adjusting it to good RSpec style (http://betterspecs.org/).
-# Please improve it whenever adding examples.
-
 require_relative "test_helper"
 
 require "yast/path"
 
-describe "PathTest" do
-  it "tests initialize" do
-    expect(Yast::Path.new(".etc").to_s).to eq(".etc")
-    expect(Yast::Path.new('.et?c').to_s).to eq('."et?c"')
+describe "Yast::Path" do
+  describe "#initialize" do
+    it "works for simple paths" do
+      expect(Yast::Path.new(".etc").to_s).to eq(".etc")
+    end
+    it "works for complex paths" do
+      expect(Yast::Path.new('.et?c').to_s).to eq('."et?c"')
+    end
   end
 
-  it "tests load from string" do
-    expect(Yast::Path.from_string("etc").to_s).to eq(".\"etc\"")
-    expect(Yast::Path.from_string('et?c').to_s).to eq('."et?c"')
+  describe ".from_string" do
+    it "works for simple paths" do
+      expect(Yast::Path.from_string("etc").to_s).to eq(".\"etc\"")
+    end
+    it "works for complex paths" do
+      expect(Yast::Path.from_string('et?c').to_s).to eq('."et?c"')
+    end
   end
 
-  it "tests add" do
-    root = Yast::Path.new '.'
-    etc = Yast::Path.new '.etc'
-    sysconfig = Yast::Path.new '.sysconfig'
-    expect((etc + sysconfig).to_s).to eq(".etc.sysconfig")
-    expect((etc + 'sysconfig').to_s).to eq('.etc."sysconfig"')
-    expect((root+root).to_s).to eq('.')
-    expect((root+etc).to_s).to eq('.etc')
-    expect((etc+root).to_s).to eq('.etc')
+  describe "#+" do
+    it "works" do
+      root = Yast::Path.new '.'
+      etc = Yast::Path.new '.etc'
+      sysconfig = Yast::Path.new '.sysconfig'
+      expect((etc + sysconfig).to_s).to eq(".etc.sysconfig")
+      expect((etc + 'sysconfig').to_s).to eq('.etc."sysconfig"')
+      expect((root+root).to_s).to eq('.')
+      expect((root+etc).to_s).to eq('.etc')
+      expect((etc+root).to_s).to eq('.etc')
+    end
   end
 
-  it "tests equals" do
-    expect(Yast::Path.new(".\"\x1A\"")).to eq(Yast::Path.new(".\"\x1a\""))
-    expect(Yast::Path.new(".\"A\"")).to eq(Yast::Path.new(".\"\x41\""))
-    expect(Yast::Path.new('.')).to_not eq(Yast::Path.new(".\"\""))
+  describe "#<=>" do
+    it "works for equality with Path" do
+      expect(Yast::Path.new(".\"\x1A\"")).to eq(Yast::Path.new(".\"\x1a\""))
+      expect(Yast::Path.new(".\"A\"")).to eq(Yast::Path.new(".\"\x41\""))
+      expect(Yast::Path.new('.')).to_not eq(Yast::Path.new(".\"\""))
+    end
+
+    it "works for ordering Paths" do
+      expect(Yast::Path.new('.ba')).to be >= Yast::Path.new('."a?"')
+      expect(Yast::Path.new('."b?"')).to be >= Yast::Path.new('.ab')
+    end
   end
 
-  it "tests comparison" do
-    expect(Yast::Path.new('.ba')).to be >= Yast::Path.new('."a?"')
-    expect(Yast::Path.new('."b?"')).to be >= Yast::Path.new('.ab')
-  end
-
-  it "tests clone" do
-    etc = Yast::Path.new '.etc.sysconfig.DUMP'
-    expect(etc.clone.to_s).to eq('.etc.sysconfig.DUMP')
+  describe "#clone" do
+    it "works" do
+      etc = Yast::Path.new '.etc.sysconfig.DUMP'
+      expect(etc.clone.to_s).to eq('.etc.sysconfig.DUMP')
+    end
   end
 end

--- a/tests/ruby/path_spec.rb
+++ b/tests/ruby/path_spec.rb
@@ -48,6 +48,11 @@ describe "Yast::Path" do
       expect(Yast::Path.new('.ba')).to be >= Yast::Path.new('."a?"')
       expect(Yast::Path.new('."b?"')).to be >= Yast::Path.new('.ab')
     end
+
+    # bsc#933470
+    it "survives comparison with a non-Path" do
+      expect(Yast::Path.new('.foo') <=> 42).to eq nil
+    end
   end
 
   describe "#clone" do

--- a/tests/ruby/term_spec.rb
+++ b/tests/ruby/term_spec.rb
@@ -1,10 +1,6 @@
 #!/usr/bin/env rspec
 # encoding: utf-8
 
-# FIXME: this file was autoconverted from test/unit syntax without
-# adjusting it to good RSpec style (http://betterspecs.org/).
-# Please improve it whenever adding examples.
-
 require_relative "test_helper"
 
 require "yast/term"
@@ -47,7 +43,7 @@ describe Yast::Term do
     end
   end
 
-  describe "#<<" do
+  describe "#<<" do             #  " <- unconfuse Emacs string highlighting
     it "appends parameter to params" do
       t = term(:HBox, 1, 2)
       t << 3
@@ -55,7 +51,7 @@ describe Yast::Term do
     end
   end
 
-  describe "comparison" do
+  describe "#<=> (comparison)" do
     it "if value and params are equal, then it is equal terms" do
       expect(term(:HBox)).to eq(term(:HBox))
     end
@@ -74,6 +70,10 @@ describe Yast::Term do
 
     it "if value is equal, then use params to comparison" do
       expect(term(:HBox, "test")).to be > term(:HBox)
+    end
+
+    it "if non-term, then uncomparable" do
+      expect(term(:HBox, "test") <=> 42).to eq nil
     end
   end
 


### PR DESCRIPTION
https://bugzilla.suse.com/show_bug.cgi?id=933470

Term and Path would raise exceptions when <=> was used to compare them
with something that was not a Term or Path.

In particular it happened during RSpec argument matching.

In older Ruby core, Comparable#== would silently mask such exceptions,
now it started producing warnings.
https://bugs.ruby-lang.org/issues/7688