### PR TITLE
Test for bnc#943757, fixed in libyui-ncurses 2.47.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
     # disable rvm, use system Ruby
     - rvm reset
     - wget https://raw.githubusercontent.com/yast/yast-devtools/master/travis-tools/travis_setup.sh
-    - sh ./travis_setup.sh -p "docbook-xsl xsltproc yast2-core-dev yast2-devtools libxcrypt-dev cmake yast2-ycp-ui-bindings-dev ruby2.1 ruby2.1-dev rake ruby-fast-gettext language-pack-en language-pack-cs" -g "yast-rake rspec:3.3.0 rubocop:0.29.1"
+    - sh ./travis_setup.sh -p "docbook-xsl xsltproc yast2-core-dev yast2-devtools libxcrypt-dev cmake yast2-ycp-ui-bindings-dev ruby2.1 ruby2.1-dev rake ruby-fast-gettext language-pack-en language-pack-cs screen" -g "yast-rake rspec:3.3.0 rubocop:0.29.1"
 script:
     - rake check:syntax
     - rubocop

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -45,6 +45,8 @@ BuildRequires:  yast2-ycp-ui-bindings-devel >= 2.21.9
 # The test suite includes a regression test (std_streams_spec.rb) for a
 # libyui-ncurses bug fixed in 2.47.3
 BuildRequires:  libyui-ncurses >= 2.47.3
+# The mentioned test requires screen in order to be executed in headless systems
+BuildRequires:  screen
 Requires:       ruby
 Summary:        Ruby bindings for the YaST platform
 License:        GPL-2.0

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -42,6 +42,9 @@ Requires:       yast2-core >= 2.24.0
 BuildRequires:  yast2-core-devel >= 2.24.0
 Requires:       yast2-ycp-ui-bindings       >= 2.21.9
 BuildRequires:  yast2-ycp-ui-bindings-devel >= 2.21.9
+# The test suite includes a regression test (std_streams_spec.rb) for a
+# libyui-ncurses bug fixed in 2.47.3
+BuildRequires:  libyui-ncurses >= 2.47.3
 Requires:       ruby
 Summary:        Ruby bindings for the YaST platform
 License:        GPL-2.0

--- a/tests/ruby/CMakeLists.txt
+++ b/tests/ruby/CMakeLists.txt
@@ -9,3 +9,5 @@ FILE(GLOB Specs "*_spec.rb")
 foreach(test ${Specs})
     ADD_TEST(${test}   rspec --format doc ${test})
 endforeach(test)
+
+ADD_TEST("integration"  ruby ${CMAKE_CURRENT_SOURCE_DIR}/integration/run.rb)

--- a/tests/ruby/integration/run.rb
+++ b/tests/ruby/integration/run.rb
@@ -1,0 +1,20 @@
+#!/usr/bin/env ruby
+
+# std_streams_spec.rb is used to verify that bnc#943757 is fixed in
+# libyui-ncurses >= 2.47.3. Thus, is an integration test for YaST+libyui
+#
+# It runs perfectly in a regular system by just calling
+#   rspec std_streams_spec.rb
+# but headless systems like jenkins need this script to fake the screen
+
+test = File.dirname(__FILE__) + "/std_streams_spec.rb"
+cmd = "rspec #{test}"
+
+`screen -D -m sh -c '#{cmd}; echo \$? > /tmp/exit'`
+if File.read("/tmp/exit") != "0\n"
+  puts "Test failed: '#{cmd}'. Rerun manually to see the cause."
+  exit false
+else
+  puts "Test succeeded."
+  exit true
+end

--- a/tests/ruby/integration/std_streams_spec.rb
+++ b/tests/ruby/integration/std_streams_spec.rb
@@ -3,7 +3,7 @@
 # We do not have a proper ncurses in travis at the moment
 exit 0 if ENV["TRAVIS"]
 
-require_relative "test_helper"
+require_relative "../test_helper"
 require "yast/ui_shortcuts"
 
 Yast.import "UI"

--- a/tests/ruby/std_streams_spec.rb
+++ b/tests/ruby/std_streams_spec.rb
@@ -1,42 +1,40 @@
 #! /usr/bin/env rspec
 
+# We do not have a proper ncurses in travis at the moment
+exit 0 if ENV["TRAVIS"]
+
 require_relative "test_helper"
 require "yast/ui_shortcuts"
 
 Yast.import "UI"
 
-# We do not have a proper ncurses in travis at the moment
-if !ENV["TRAVIS"]
-  def std_puts(message)
-    $stdout.puts "stdout: #{message}"
-    $stderr.puts "stderr: #{message}"
+def std_puts(message)
+  $stdout.puts "stdout: #{message}"
+  $stderr.puts "stderr: #{message}"
+end
+
+# Regression test for the fix of bnc#943757 implemented
+# in libyui-ncurses 2.47.3
+describe "streams redirection in libyui-ncurses" do
+  include Yast::UIShortcuts
+
+  around do |example|
+    Yast.ui_component = "ncurses"
+    Yast::UI.OpenUI
+    example.run
+    Yast::UI.CloseUI
+
+    # Having an expectation in the around block looks weird, but using around
+    # to execute OpenUI/CloseUI was needed to make the bug pop up.
+    #
+    # In addition to not crashing, these messages should be displayed when
+    # running RSpec, not sure if it's possible to check that.
+    expect { std_puts "tty is free again" }.to_not raise_error
   end
 
-  # Regression test for the fix of bnc#943757 implemented
-  # in libyui-ncurses 2.47.3
-  describe "streams redirection in libyui-ncurses" do
-    include Yast::UIShortcuts
-
-    before do
-      Yast.ui_component = "ncurses"
-      Yast::UI.OpenUI
-    end
-
-    after do
-      Yast::UI.CloseUI
-
-      # Having an expectation in the after block looks weird, but using
-      # before/after to execute OpenUI/CloseUI was needed to make the bug popup
-      #
-      # In addition to not crashing, these messages should be displayed when
-      # running RSpec, not sure if it's possible to check that
-      expect { std_puts "tty is free again" }.to_not raise_error
-    end
-
-    it "does not fall apart when stderr is used" do
-      Yast::UI.OpenDialog(PushButton("Hello, World!"))
-      expect { std_puts "NCurses is using the tty" }.to_not raise_error
-      Yast::UI.CloseDialog
-    end
+  it "does not fall apart when stderr is used" do
+    Yast::UI.OpenDialog(PushButton("Hello, World!"))
+    expect { std_puts "NCurses is using the tty" }.to_not raise_error
+    Yast::UI.CloseDialog
   end
 end

--- a/tests/ruby/std_streams_spec.rb
+++ b/tests/ruby/std_streams_spec.rb
@@ -30,12 +30,12 @@ if !ENV["TRAVIS"]
       #
       # In addition to not crashing, these messages should be displayed when
       # running RSpec, not sure if it's possible to check that
-      expect {std_puts "tty is free again"}.to_not raise_error
+      expect { std_puts "tty is free again" }.to_not raise_error
     end
 
     it "does not fall apart when stderr is used" do
       Yast::UI.OpenDialog(PushButton("Hello, World!"))
-      expect {std_puts "NCurses is using the tty"}.to_not raise_error
+      expect { std_puts "NCurses is using the tty" }.to_not raise_error
       Yast::UI.CloseDialog
     end
   end

--- a/tests/ruby/std_streams_spec.rb
+++ b/tests/ruby/std_streams_spec.rb
@@ -1,0 +1,42 @@
+#! /usr/bin/env rspec
+
+require_relative "test_helper"
+require "yast/ui_shortcuts"
+
+Yast.import "UI"
+
+# We do not have a proper ncurses in travis at the moment
+if !ENV["TRAVIS"]
+  def std_puts(message)
+    $stdout.puts "stdout: #{message}"
+    $stderr.puts "stderr: #{message}"
+  end
+
+  # Regression test for the fix of bnc#943757 implemented
+  # in libyui-ncurses 2.47.3
+  describe "streams redirection in libyui-ncurses" do
+    include Yast::UIShortcuts
+
+    before do
+      Yast.ui_component = "ncurses"
+      Yast::UI.OpenUI
+    end
+
+    after do
+      Yast::UI.CloseUI
+
+      # Having an expectation in the after block looks weird, but using
+      # before/after to execute OpenUI/CloseUI was needed to make the bug popup
+      #
+      # In addition to not crashing, these messages should be displayed when
+      # running RSpec, not sure if it's possible to check that
+      expect {std_puts "tty is free again"}.to_not raise_error
+    end
+
+    it "does not fall apart when stderr is used" do
+      Yast::UI.OpenDialog(PushButton("Hello, World!"))
+      expect {std_puts "NCurses is using the tty"}.to_not raise_error
+      Yast::UI.CloseDialog
+    end
+  end
+end


### PR DESCRIPTION
I didn't manage to write a test reproducing the bug in libyui-test, so I wrote a test here (which, on the other hand, fits better the bug description, since YaST and Ruby are involved).

Should we add ```BuildRequires: libyui-ncurses >= 2.47.3``` to the spec file? I find it a little bit overkill, but I'm open to suggestions.

This can be merged after https://github.com/libyui/libyui-ncurses/pull/40 or https://github.com/libyui/libyui-ncurses/pull/41 (whichever wins the contest), since both make the test happy.