### PR TITLE
Do not crash when logging an invalid UTF-8 string (bsc#932014)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 11 12:56:37 UTC 2016 - lslezak@suse.cz
+
+- Do not crash when logging an invalid UTF-8 string (bsc#932014)
+- 3.1.43
+
+-------------------------------------------------------------------
 Tue Dec  1 16:06:11 UTC 2015 - jreidinger@suse.com
 
 - Reverted the last change because it broke updating the table in

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.42
+Version:        3.1.43
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/tests/ruby/y2logger_spec.rb
+++ b/tests/ruby/y2logger_spec.rb
@@ -41,6 +41,21 @@ module Yast
       expect(Yast).to receive(:y2milestone).with(Y2Logger::CALL_FRAME, TEST_MESSAGE)
       @test_logger.info { TEST_MESSAGE }
     end
+
+    it "does not crash when logging an invalid UTF-8 string" do
+      # do not process this string otherwise you'll get an exception :-)
+      invalid_utf8 = "invalid sequence: \xE3\x80"
+      # just make sure it is really an UTF-8 string
+      expect(invalid_utf8.encoding).to eq(Encoding::UTF_8)
+      expect { Yast.y2milestone(invalid_utf8) }.not_to raise_error
+    end
+
+    it "does not crash when logging ASCII string with invalid UTF-8" do
+      # do not process this string otherwise you'll get an exception :-)
+      invalid_ascii = "invalid sequence: \xE3\x80"
+      invalid_ascii.force_encoding(Encoding::ASCII)
+      expect { Yast.y2milestone(invalid_ascii) }.not_to raise_error
+    end
   end
 
   describe Yast::Logger do


### PR DESCRIPTION
- 3.1.43

Fixes https://bugzilla.suse.com/show_bug.cgi?id=932014