### PR TITLE
Fix Encoding name conflict

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Jan 12 15:05:40 UTC 2016 - lslezak@suse.cz
+
+- Fixed conflict between Yast::Encoding and ::Encoding (another fix
+  for bsc#932014)
+- 3.1.44
+
+-------------------------------------------------------------------
 Mon Jan 11 12:56:37 UTC 2016 - lslezak@suse.cz
 
 - Do not crash when logging an invalid UTF-8 string (bsc#932014)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.43
+Version:        3.1.44
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/logger.rb
+++ b/src/ruby/yast/logger.rb
@@ -26,11 +26,13 @@ module Yast
     safe_args = args.map do |arg|
       return arg unless arg.is_a?(::String)
 
-      if arg.encoding == Encoding::UTF_8
+      # Be carefull, there is also Yast::Encoding!!
+      if arg.encoding == ::Encoding::UTF_8
         arg.scrub("�")
       else
         # broken strings might be passed as e.g. ASCII-8BIT and need to be recoded
-        arg.encode(Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�")
+        # Be carefull, there is also Yast::Encoding!!
+        arg.encode(::Encoding::UTF_8, invalid: :replace, undef: :replace, replace: "�")
       end
     end
 


### PR DESCRIPTION
Fixes conflict between `Yast::Encoding` and `::Encoding` (from std Ruby).