### PR TITLE
Debugger support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -67,3 +67,8 @@ Style/SingleLineBlockParams:
 # Offense count: 1 (@__last_exception)
 Style/TrivialAccessors:
   Enabled: false
+
+# the debugger invocation is deliberate here, it's not a forgotten leftover...
+Lint/Debugger:
+  Exclude:
+    - src/ruby/yast/debugger.rb

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon May 23 12:30:17 UTC 2016 - lslezak@suse.cz
+
+- Added support for running the Ruby debugger (FATE#318421)
+- Allow running the Ruby debugger from the generic crash handler
+  if the debugger is installed
+- 3.1.47
+
+-------------------------------------------------------------------
 Mon Mar  7 16:12:00 UTC 2016 - jreidinger@suse.com
 
 - update code according to updated yast ruby style guide

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.46
+Version:        3.1.47
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -47,6 +47,9 @@ BuildRequires:  yast2-ycp-ui-bindings-devel >= 2.21.9
 BuildRequires:  libyui-ncurses >= 2.47.3
 # The mentioned test requires screen in order to be executed in headless systems
 BuildRequires:  screen
+
+# only a soft dependency, the Ruby debugger is optional
+Suggests:       rubygem(%{rb_default_ruby_abi}:byebug)
 
 # Unfortunately we cannot move this to macros.yast,
 # bcond within macros are ignored by osc/OBS.

--- a/src/ruby/yast/debugger.rb
+++ b/src/ruby/yast/debugger.rb
@@ -1,0 +1,157 @@
+
+require "yast"
+
+module Yast
+  class Debugger
+    class << self
+      include Yast::Logger
+      include Yast::UIShortcuts
+
+      # Start the Ruby debugger. It handles the current UI mode and displays
+      # an user request if the debugger front-end needs to be started manually.
+      # @param [Boolean] remote if set to true the server is accesible from network.
+      #   By default the debugger can connect only from the local machine, not from
+      #   the network. If you need remote debugging then enable it.
+      #   WARNING: There is no authentication, everybody can connect to
+      #   the debugger! Use only in a trusted network as this is actually
+      #   a backdoor to the system! For secure connection use SSH and start
+      #   the debugger locally after connecting via SSH.
+      # @param [Fixnum] port the port number where the debugger server will
+      #   listen to
+      # @param [Boolean] start_client autostart the debugger client
+      #   (ignored in remote debugging)
+      # @example Start the debugger with default settings:
+      #   require "yast/debugger"
+      #   Yast::Debugger.start
+      # @example When using the debugger temporary you can use just simple:
+      #   require "byebug"
+      #   byebug
+      def start(remote: false, port: 3344, start_client: true)
+        begin
+          require "byebug"
+          require "byebug/core"
+        rescue LoadError
+          # catch loading error, the debugger is optional (might not be present)
+          Yast.import "Report"
+          Report.Error(format("Cannot load the Ruby debugger.\n" \
+            "Make sure '%s' Ruby gem is installed.") % "byebug")
+          return
+        end
+
+        popup = false
+
+        # do not start the server if it is already running
+        if Byebug.started?
+          log.warn "The debugger is already running at port #{Byebug.actual_port}"
+          log.warn "Skipping the server setup"
+        else
+          Yast.import "UI"
+          wait = false
+          if UI.TextMode || remote || !start_client
+            # in textmode or in remote mode ask the user to start
+            # the debugger client manually
+            UI.OpenDialog(Label(debugger_message(remote, port)))
+            popup = true
+          else
+            # in GUI open an xterm session with the debugger
+            start_gui_session(port)
+            # wait a bit to get the server ready (to avoid "Broken pipe" error)
+            # FIXME: looks like a race condition inside byebug itself...
+            wait = true
+          end
+
+          # start the server and wait for connection
+          start_server(remote, port, wait)
+
+          UI.CloseDialog if popup
+        end
+
+        # start the debugger session
+        byebug
+        # Now you can inspect the current state in the debugger,
+        # or use "next" to continue.
+        # Use "help" command to see the available commands, see more at
+        # https://github.com/deivid-rodriguez/byebug/blob/master/GUIDE.md
+      end
+
+      # is the Ruby debugger installed and can be loaded?
+      # @return [Boolean] true if the debugger is present
+      def installed?
+        require "byebug"
+        true
+      rescue LoadError
+        false
+      end
+
+    private
+
+      # starts the debugger server and waits for a cleint connection
+      # @param [Boolean] remote if set to true the server is accesible from network
+      # @param [Fixnum] port the port number used by the server
+      def start_server(remote, port, wait)
+        Byebug.wait_connection = true
+        host = remote ? "0.0.0.0" : "localhost"
+        log.info "Starting debugger server (#{host}:#{port}), waiting for connection..."
+        Byebug.start_server(host, port)
+        sleep(3) if wait
+      end
+
+      # starts a debugger session in xterm
+      # @param [Fixnum] port the port number to connect to
+      def start_gui_session(port)
+        job = fork do
+          # wait until the main thread starts the debugger and opens the port
+          # for listening
+          loop do
+            break if port_open?(port)
+            sleep(1)
+          end
+
+          # start the debugger client in an xterm session
+          exec "xterm", "-e", "byebug", "-R", "#{port}"
+        end
+
+        # detach the process, we do not wait for it so avoid zombies
+        Process.detach(job)
+      end
+
+      # compose the popup message describing how to manually connect to
+      # the running debugger
+      # @return [String] text
+      def debugger_message(remote, port)
+        waiting = "Waiting for the connection..."
+        if remote
+          # get the local IP addresses
+          require "socket"
+          remote_ips = Socket.ip_address_list.select { |a| a.ipv4? && !a.ipv4_loopback? }
+          cmds = remote_ips.map { |a| debugger_cmd(a.ip_address, port) }.join("\n")
+
+          "To connect to the debugger from a remote machine use this command:" \
+            "\n\n#{cmds}\n\n#{waiting}"
+        else
+          "To start the debugger switch to another console and run\n\n" \
+            "#{debugger_cmd(nil, port)}\n\n#{waiting}"
+        end
+      end
+
+      def debugger_cmd(host, port)
+        host_param = host ? "#{host}:" : ""
+        "    byebug -R #{host_param}#{port}"
+      end
+
+      # is the target port open?
+      # @param [Fixnum] port the port number
+      # @return [Boolean] true if the port is open, false otherwise
+      def port_open?(port)
+        require "socket"
+
+        begin
+          TCPSocket.new("localhost", port).close
+          true
+        rescue Errno::ECONNREFUSED, Errno::EHOSTUNREACH
+          false
+        end
+      end
+    end
+  end
+end

--- a/tests/ruby/y2logger_spec.rb
+++ b/tests/ruby/y2logger_spec.rb
@@ -44,15 +44,16 @@ module Yast
 
     it "does not crash when logging an invalid UTF-8 string" do
       # do not process this string otherwise you'll get an exception :-)
-      invalid_utf8 = "invalid sequence: \xE3\x80"
-      # just make sure it is really an UTF-8 string
-      expect(invalid_utf8.encoding).to eq(Encoding::UTF_8)
+      invalid_utf8 = "invalid sequence: " + 0xE3.chr + 0x80.chr
+      # just make sure it is really an invalid UTF-8 string
+      invalid_utf8.force_encoding(Encoding::UTF_8)
+      expect(invalid_utf8.valid_encoding?).to eq(false)
       expect { Yast.y2milestone(invalid_utf8) }.not_to raise_error
     end
 
     it "does not crash when logging ASCII string with invalid UTF-8" do
       # do not process this string otherwise you'll get an exception :-)
-      invalid_ascii = "invalid sequence: \xE3\x80"
+      invalid_ascii = "invalid sequence: " + 0xE3.chr + 0x80.chr
       invalid_ascii.force_encoding(Encoding::ASCII)
       expect { Yast.y2milestone(invalid_ascii) }.not_to raise_error
     end


### PR DESCRIPTION
- Added `yast/debugger` for generic handling of the Ruby debugger (to be used in the installer, see [FATE#318421](https://fate.suse.com/318421), the installer part is implemented in this PR: https://github.com/yast/yast-installation/pull/379).

## Bonus 

- Allow running the debugger from the generic crash handler, see the screenshots below.

### Screenshots

The original generic crash handler displays a popup like this:

![debugger_crash_orig_popup](https://cloud.githubusercontent.com/assets/907998/15471622/35f81882-20f7-11e6-9c04-c0bce84731fe.png)

With this patch when the `byebug` Ruby gem is installed it displays this:

![debugger_crash_popup](https://cloud.githubusercontent.com/assets/907998/15471891/a4a022f6-20f8-11e6-89b3-a7b0001977af.png)


Which when confirmed starts the debug session in a new `xterm` window:

![debugger_crash_started](https://cloud.githubusercontent.com/assets/907998/15471660/70d2ff26-20f7-11e6-974c-c31577269c79.png)

In the text mode we cannot start the `xterm` session automatically, you have to start the debugger front end manually:

![debugger_crash_popup_ncurses](https://cloud.githubusercontent.com/assets/907998/15471783/1a857ae4-20f8-11e6-8ec3-b9c6770cdbeb.png)
