### PR TITLE
Improve the debugger support (FATE#318421)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Mon May 30 14:38:02 UTC 2016 - lslezak@suse.cz
+
+- Improve the debugger support - use the same code also at run
+  time, allow using `Y2DEBUGGER` also in installed system
+  (FATE#318421)
+- 3.1.48
+
+-------------------------------------------------------------------
 Mon May 23 12:30:17 UTC 2016 - lslezak@suse.cz
 
 - Added support for running the Ruby debugger (FATE#318421)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.47
+Version:        3.1.48
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/debugger.rb
+++ b/src/ruby/yast/debugger.rb
@@ -62,14 +62,16 @@ module Yast
         # https://github.com/deivid-rodriguez/byebug/blob/master/GUIDE.md
       end
 
-      # start the Ruby debugger if "Y2DEBUGGER" or "y2debugger" environment
-      # variable is set to "1", "remote" or "manual"
+      # start the Ruby debugger if "Y2DEBUGGER" environment
+      # variable is set to "1", "remote" or "manual" (the test is case
+      # insensitive, "y2debugger" variable can be also used)
       def start_from_env
-        # do not start the debugger again for each client started, run it only
-        # once for the very first client
-        return if @debugger_started
+        # do not evaluate the debugger request again for each client started,
+        # run the debugger evaluation only once
+        return if @debugger_handled
+        @debugger_handled = true
 
-        debug = read_dbg_env
+        debug = env_value
         return if debug != "1" && debug != "remote" && debug != "manual"
 
         # FIXME: the UI.TextMode call is used here just to force the UI
@@ -81,7 +83,6 @@ module Yast
 
         log.info "Debugger set to: #{debug}"
         start(remote: debug == "remote", start_client: debug != "manual")
-        @debugger_started = true
       end
 
       # is the Ruby debugger installed and can be loaded?
@@ -98,7 +99,7 @@ module Yast
       # read the debugger value from Y2DEBUGGER environment variable,
       # do case insensitive match
       # @return [String,nil] environment value or nil if not defined
-      def read_dbg_env
+      def env_value
         # sort the keys to have a deterministic behavior and to prefer Y2DEBUGGER
         # over the other variants, then do a case insensitive search
         key = ENV.keys.sort.find { |k| k.match(/\AY2DEBUGGER\z/i) }

--- a/src/ruby/yast/debugger.rb
+++ b/src/ruby/yast/debugger.rb
@@ -69,9 +69,7 @@ module Yast
         # once for the very first client
         return if @debugger_started
 
-        # support both upcase and down case variants, linuxrc
-        # keeps the case and it is case insensitive for the other options
-        debug = ENV["Y2DEBUGGER"] || ENV["y2debugger"]
+        debug = read_dbg_env
         return if debug != "1" && debug != "remote" && debug != "manual"
 
         # FIXME: the UI.TextMode call is used here just to force the UI
@@ -96,6 +94,17 @@ module Yast
       end
 
     private
+
+      # read the debugger value from Y2DEBUGGER environment variable,
+      # do case insensitive match
+      # @return [String,nil] environment value or nil if not defined
+      def read_dbg_env
+        # sort the keys to have a deterministic behavior and to prefer Y2DEBUGGER
+        # over the other variants, then do a case insensitive search
+        key = ENV.keys.sort.find { |k| k.match(/\AY2DEBUGGER\z/i) }
+        log.debug "Found debugger key: #{key.inspect}"
+        key ? ENV[key] : nil
+      end
 
       # load the Ruby debugger, report an error on failure
       # @return [Boolean] true if the debugger was loaded successfuly,

--- a/src/ruby/yast/debugger.rb
+++ b/src/ruby/yast/debugger.rb
@@ -62,6 +62,30 @@ module Yast
         # https://github.com/deivid-rodriguez/byebug/blob/master/GUIDE.md
       end
 
+      # start the Ruby debugger if "Y2DEBUGGER" or "y2debugger" environment
+      # variable is set to "1", "remote" or "manual"
+      def start_from_env
+        # do not start the debugger again for each client started, run it only
+        # once for the very first client
+        return if @debugger_started
+
+        # support both upcase and down case variants, linuxrc
+        # keeps the case and it is case insensitive for the other options
+        debug = ENV["Y2DEBUGGER"] || ENV["y2debugger"]
+        return if debug != "1" && debug != "remote" && debug != "manual"
+
+        # FIXME: the UI.TextMode call is used here just to force the UI
+        # initialization, if it is initialized inside the start method the
+        # ncurses UI segfaults :-(
+        # interestengly, the Qt UI works correctly...
+        Yast.import "UI"
+        log.info "text mode: #{UI.TextMode}"
+
+        log.info "Debugger set to: #{debug}"
+        start(remote: debug == "remote", start_client: debug != "manual")
+        @debugger_started = true
+      end
+
       # is the Ruby debugger installed and can be loaded?
       # @return [Boolean] true if the debugger is present
       def installed?

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -1,6 +1,8 @@
 require "yast/builtinx"
 require "yast/builtins"
 require "yast/ops"
+require "yast/logger"
+require "yast/debugger"
 
 # @private we need it as clients is called in global contenxt
 GLOBAL_WFM_CONTEXT = proc {}
@@ -8,6 +10,8 @@ module Yast
   # Wrapper class for WFM component in Yast
   # See yast documentation for WFM
   module WFM
+    extend Yast::Logger
+
     # Returns list of arguments passed to client or element at given index
     #
     # @example Get all args
@@ -200,6 +204,7 @@ module Yast
       Builtins.y2milestone "Call client %1", client
       code = File.read client
       begin
+        debugger_from_env
         result = eval(code, GLOBAL_WFM_CONTEXT.binding, client)
 
         allowed_types = Ops::TYPES_MAP.values.flatten
@@ -246,6 +251,30 @@ module Yast
         end
         return false
       end
+    end
+
+    # start the Ruby debugger if "Y2DEBUGGER" or "y2debugger" environment
+    # variable is set to "1", "remote" or "manual"
+    def self.debugger_from_env
+      # do not start the debugger again for each client started, run it only
+      # once for the very first client
+      return if @debugger_started
+
+      # support both upcase and down case variants, linuxrc
+      # keeps the case and it is case insensitive for the other options
+      debug = ENV["Y2DEBUGGER"] || ENV["y2debugger"]
+      return if debug != "1" && debug != "remote" && debug != "manual"
+
+      # FIXME: the UI.TextMode call is used here just to force the UI
+      # initialization, if it is initialized inside the Debugger module the
+      # ncurses UI segfaults :-(
+      # interestengly, the Qt UI works correctly...
+      Yast.import "UI"
+      log.info "text mode: #{UI.TextMode}"
+
+      log.info "Debugger set to: #{debug}"
+      Debugger.start(remote: debug == "remote", start_client: debug != "manual")
+      @debugger_started = true
     end
   end
 end


### PR DESCRIPTION
Use the same code also at run time, allow using `Y2DEBUGGER` also in installed system.

Now you can run `Y2DEBUGGER=1 yast2 <client>` and the debugger window will automatically pop up.

- 3.1.48