### PR TITLE
Rescue "invalid byte sequence in UTF-8", with a custom message

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Fri Sep 16 10:28:16 UTC 2016 - mvidner@suse.com
+
+- Rescue "invalid byte sequence in UTF-8", with a custom message
+  (bsc#992821).
+- 3.1.51
+
+-------------------------------------------------------------------
 Thu Jun 30 09:24:32 UTC 2016 - jreidinger@suse.com
 
 - Fix segfault when running rspec tests caused by added ruby

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.50
+Version:        3.1.51
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -199,7 +199,7 @@ module Yast
       if e.is_a?(ArgumentError) && e.message =~ /invalid byte sequence in UTF-8/
         msg += "A string was encountered that is not valid in UTF-8.\n" \
                "The system encoding is #{Encoding.locale_charmap.inspect}.\n" \
-               "This is a known bug bsc#992821.\n\n"
+               "Refer to https://www.suse.com/support/kb/doc?id=7018056.\n\n"
       end
 
       msg + "Details: #{e.message}\n" \

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -194,9 +194,16 @@ module Yast
     # @param [Exception] e the caught exception
     # @return [String] human readable exception description
     def self.internal_error_msg(e)
-      "Internal error. Please report a bug report with logs.\n" \
-        "Details: #{e.message}\n" \
-        "Caller:  #{e.backtrace.first}"
+      msg = "Internal error. Please report a bug report with logs.\n"
+
+      if e.is_a?(ArgumentError) && e.message =~ /invalid byte sequence in UTF-8/
+        msg += "A string was encountered that is not valid in UTF-8.\n" \
+               "The system encoding is #{Encoding.locale_charmap.inspect}.\n" \
+               "This is a known bug bsc#992821.\n\n"
+      end
+
+      msg + "Details: #{e.message}\n" \
+            "Caller:  #{e.backtrace.first}"
     end
 
     # @private wrapper to run client in ruby


### PR DESCRIPTION
[bsc#992821](https://bugzilla.suse.com/show_bug.cgi?id=992821)
