### PR TITLE
Add debugger hooks

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Nov 15 10:34:51 UTC 2016 - lslezak@suse.cz
+
+- Improved debugger support: catch the magic debugging key
+  combination (Shift+Ctrl+Alt+D in Qt) returned by UI calls and
+  start the Ruby debugger when received (FATE#318421)
+- 3.1.51.1
+
+-------------------------------------------------------------------
 Fri Sep 16 10:28:16 UTC 2016 - mvidner@suse.com
 
 - Rescue "invalid byte sequence in UTF-8", with a custom message

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.51
+Version:        3.1.51.1
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Yast.cc
+++ b/src/binary/Yast.cc
@@ -169,12 +169,12 @@ void set_ruby_source_location(VALUE file, VALUE lineno)
 }
 
 /**
- * Is the function name an UI function which returns a symbol?
+ * Returns true if the function name in an UI user input function which returns
+ * a symbol.
  * @param  function_name name of the function
- * @return true if function_name is one of "UserInput", "TimeoutUserInput"
- *   or "PollInput"
+ * @return true/false
  */
-static bool ui_symbol_function(const char *function_name)
+static bool ui_input_function(const char *function_name)
 {
     return strcmp(function_name, "UserInput") == 0  ||
         strcmp(function_name, "TimeoutUserInput") == 0 ||
@@ -182,9 +182,9 @@ static bool ui_symbol_function(const char *function_name)
 }
 
 /**
- * Is the YCP value :debugHotkey symbol?
- * @param  val YCP value
- * @return true when val == :debugHotkey
+ * Returns true if the parameter is the :debugHotkey symbol.
+ * @param  val YCPSymbol returned from an UI input call
+ * @return true/false
  */
 static bool is_debug_symbol(YCPValue val)
 {
@@ -193,20 +193,19 @@ static bool is_debug_symbol(YCPValue val)
 }
 
 /**
- * Is the function name an UI function which returns a map?
+ * Returns true if the function_name is "WaitForEvent"
  * @param  function_name name of the function
- * @return true if function_name is "WaitForEvent"
+ * @return true/false
  */
-static bool ui_hash_function(const char *function_name)
+static bool ui_input_event_function(const char *function_name)
 {
     return strcmp(function_name, "WaitForEvent") == 0;
 }
 
 /**
- * Is the YCP value a map containg a debug UI event?
- * @param  val YCP value
- * @return true if val is map and map["EventType"] == "DebugEvent" &&
- *   map["ID"] == :debugHotkey
+ * Returns true if the input is a debug UI event.
+ * @param  val YCPMap returned from the UI::WaitForEvent call
+ * @return true/false
  */
 static bool is_debug_event(YCPValue val)
 {
@@ -234,7 +233,7 @@ static bool is_debug_event(YCPValue val)
  */
 static void start_ruby_debugger()
 {
-    y2warning("Starting the Ruby debugger...");
+    y2milestone("Starting the Ruby debugger...");
 
     rb_require("yast/debugger");
     // call "Yast::Debugger.start"
@@ -344,8 +343,8 @@ ycp_module_call_ycp_function(int argc, VALUE *argv, VALUE self)
     if (strcmp(namespace_name, "UI") == 0)
     {
         if (
-            (ui_symbol_function(function_name) && is_debug_symbol(res)) ||
-            (ui_hash_function(function_name) && is_debug_event(res))
+            (ui_input_function(function_name) && is_debug_symbol(res)) ||
+            (ui_input_event_function(function_name) && is_debug_event(res))
         )
         {
           y2milestone("UI::%s() caught magic debug key: %s", function_name, res->toString().c_str());

--- a/src/binary/Yast.cc
+++ b/src/binary/Yast.cc
@@ -169,7 +169,7 @@ void set_ruby_source_location(VALUE file, VALUE lineno)
 }
 
 /**
- * Returns true if the function name in an UI user input function which returns
+ * Returns true if the function name is an UI user input function which returns
  * a symbol.
  * @param  function_name name of the function
  * @return true/false
@@ -182,7 +182,7 @@ static bool ui_input_function(const char *function_name)
 }
 
 /**
- * Returns true if the parameter is the :debugHotkey symbol.
+ * Returns true if the input symbol starts debugging.
  * @param  val YCPSymbol returned from an UI input call
  * @return true/false
  */
@@ -193,11 +193,11 @@ static bool is_debug_symbol(YCPValue val)
 }
 
 /**
- * Returns true if the function_name is "WaitForEvent"
+ * Returns true if the function name is an event function returning a map.
  * @param  function_name name of the function
  * @return true/false
  */
-static bool ui_input_event_function(const char *function_name)
+static bool ui_event_function(const char *function_name)
 {
     return strcmp(function_name, "WaitForEvent") == 0;
 }
@@ -344,7 +344,7 @@ ycp_module_call_ycp_function(int argc, VALUE *argv, VALUE self)
     {
         if (
             (ui_input_function(function_name) && is_debug_symbol(res)) ||
-            (ui_input_event_function(function_name) && is_debug_event(res))
+            (ui_event_function(function_name) && is_debug_event(res))
         )
         {
           y2milestone("UI::%s() caught magic debug key: %s", function_name, res->toString().c_str());


### PR DESCRIPTION
Hook to the `UI::` calls and detect the debug magic key event, start the Ruby debugger when it is received.

#### Advantages

- The debugger can be started during installation or in installed system when needed, e.g. you see a strange value in a dialog, simply pressing `Shift`+`Ctrl`+`Alt`+`D` starts the debugger and you can inspect the internal state immediately

#### Disadvantages

- Only the Qt UI can send the debugging magic key (i.e. it does not work in ncurses)
- The debugger can be started only from `UI::UserInput()` and similar calls
  - If the code does not interact with user (e.g. it's waiting for an external command to finish or is cycling in an infinite loop) the debugger cannot be started

Although there are some disadvantages of this solution it is a big step forward for easier YaST debugging.