### PR TITLE
Debugger - backport to SP2

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -4,7 +4,6 @@ Tue Nov 15 10:34:51 UTC 2016 - lslezak@suse.cz
 - Improved debugger support: catch the magic debugging key
   combination (Shift+Ctrl+Alt+D in Qt) returned by UI calls and
   start the Ruby debugger when received (FATE#318421)
-- 3.1.51.1
 
 -------------------------------------------------------------------
 Fri Sep 16 10:28:16 UTC 2016 - mvidner@suse.com

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.51.1
+Version:        3.1.51
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build


### PR DESCRIPTION
This is basically a backport of #177 to SP2.

Additional changes:

- Keep the same version, this is not an urgent bug fix. It will be released later with some other real fix.