### PR TITLE
Debugger hooks

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -4,6 +4,7 @@ Tue Nov 15 10:34:51 UTC 2016 - lslezak@suse.cz
 - Improved debugger support: catch the magic debugging key
   combination (Shift+Ctrl+Alt+D in Qt) returned by UI calls and
   start the Ruby debugger when received (FATE#318421)
+- 3.2.2
 
 -------------------------------------------------------------------
 Wed Oct 26 09:46:54 UTC 2016 - jreidinger@suse.com

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov 15 10:34:51 UTC 2016 - lslezak@suse.cz
+
+- Improved debugger support: catch the magic debugging key
+  combination (Shift+Ctrl+Alt+D in Qt) returned by UI calls and
+  start the Ruby debugger when received (FATE#318421)
+
+-------------------------------------------------------------------
 Wed Oct 26 09:46:54 UTC 2016 - jreidinger@suse.com
 
 - fix crash when references passed between clients (bsc#935385)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.2.1
+Version:        3.2.2
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Yast.cc
+++ b/src/binary/Yast.cc
@@ -34,6 +34,8 @@ as published by the Free Software Foundation; either version
 #include <ycp/YCPValue.h>
 #include <ycp/YCPVoid.h>
 #include <ycp/YCPCode.h>
+#include <ycp/YCPSymbol.h>
+#include <ycp/YCPMap.h>
 #include <ycp/YCPByteblock.h>
 #include <ycp/Import.h>
 #include <ycp/y2log.h>
@@ -166,6 +168,80 @@ void set_ruby_source_location(VALUE file, VALUE lineno)
   YaST::ee.setLinenumber(FIX2INT(lineno));
 }
 
+/**
+ * Returns true if the function name is an UI user input function which returns
+ * a symbol.
+ * @param  function_name name of the function
+ * @return true/false
+ */
+static bool ui_input_function(const char *function_name)
+{
+    return strcmp(function_name, "UserInput") == 0  ||
+        strcmp(function_name, "TimeoutUserInput") == 0 ||
+        strcmp(function_name, "PollInput") == 0;
+}
+
+/**
+ * Returns true if the input symbol starts debugging.
+ * @param  val YCPSymbol returned from an UI input call
+ * @return true/false
+ */
+static bool is_debug_symbol(YCPValue val)
+{
+    return !val.isNull() && val->isSymbol() &&
+        val->asSymbol()->symbol() == "debugHotkey";
+}
+
+/**
+ * Returns true if the function name is an event function returning a map.
+ * @param  function_name name of the function
+ * @return true/false
+ */
+static bool ui_event_function(const char *function_name)
+{
+    return strcmp(function_name, "WaitForEvent") == 0;
+}
+
+/**
+ * Returns true if the input is a debug UI event.
+ * @param  val YCPMap returned from the UI::WaitForEvent call
+ * @return true/false
+ */
+static bool is_debug_event(YCPValue val)
+{
+    // is it a map?
+    if (val.isNull() || !val->isMap())
+        return false;
+
+    YCPMap map = val->asMap();
+
+    YCPValue event_type = map->value(YCPString("EventType"));
+    // is map["EventType"] == "DebugEvent"?
+    if (event_type.isNull() || !event_type->isString() ||
+        event_type->asString()->value() != "DebugEvent")
+        return false;
+
+    YCPValue event_id = map->value(YCPString("ID"));
+    // is map["ID"] == :debugHotkey?
+    return !event_id.isNull() && event_id->isSymbol() &&
+        event_id->asSymbol()->symbol() == "debugHotkey";
+}
+
+/**
+ * Start the Ruby debugger, it calls "Yast::Debugger.start" Ruby code.
+ * See file ../ruby/yast/debugger.rb for more details.
+ */
+static void start_ruby_debugger()
+{
+    y2milestone("Starting the Ruby debugger...");
+
+    rb_require("yast/debugger");
+    // call "Yast::Debugger.start"
+    VALUE module = rb_const_get(rb_cObject, rb_intern("Yast"));
+    VALUE klass = rb_const_get(module, rb_intern("Debugger"));
+    rb_funcall(klass, rb_intern("start"), 0);
+}
+
 /*
  * call_ycp_function
  *
@@ -261,6 +337,21 @@ ycp_module_call_ycp_function(int argc, VALUE *argv, VALUE self)
       RB_GC_GUARD(val);
       rb_funcall(argv[i->first], rb_intern("value="), 1, val);
     }
+
+    // hack: handle the Shift+Ctrl+Alt+D debugging magic key combination
+    // returned from UI calls, start the Ruby debugger when the magic key is received
+    if (strcmp(namespace_name, "UI") == 0)
+    {
+        if (
+            (ui_input_function(function_name) && is_debug_symbol(res)) ||
+            (ui_event_function(function_name) && is_debug_event(res))
+        )
+        {
+          y2milestone("UI::%s() caught magic debug key: %s", function_name, res->toString().c_str());
+          start_ruby_debugger();
+        }
+    }
+
     return ycpvalue_2_rbvalue(res);
   }
 }


### PR DESCRIPTION
Hook to the `UI::` calls and detect the debug magic key event, start the Ruby debugger when it is received.

# Blog Text (Proposal)

We have improved the Ruby debugger integration in YaST. So far you could start the debugger using the `y2debugger=1` boot option or by setting the `Y2DEBUGGER=1` environment variable. The new feature allows starting the Ruby debugger also later when the YaST module is already running.

Simply press `Shift`+`Ctrl`+`Alt`+`D` magic key combination (`D` as debug) and it will start the Ruby debugger. It works during installation and also in installed system (just make sure the `byebug` Ruby gem is installed).

Unfortunately this new feature works only in the Qt UI, the ncurses UI is not supported (it currently does not handle the magic keyboard combination).

![ruby_debugger](https://cloud.githubusercontent.com/assets/907998/20309290/afb5a376-ab47-11e6-8094-7cd0ca387cb8.gif)
