### PR TITLE
Do not crash when empty.mo is missing

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Dec 15 16:29:13 UTC 2016 - igonzalezsosa@suse.com
+
+- Do not crash when FastGettext is unable to find the empty.mo
+  file (bsc#1014458)
+- 3.1.24.2
+
+-------------------------------------------------------------------
 Mon Oct  5 12:04:35 UTC 2015 - jreidinger@suse.com
 
 - Used rb_gc_register_address to fix 'method to_s called on

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.24.1
+Version:        3.1.24.2
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/i18n.rb
+++ b/src/ruby/yast/i18n.rb
@@ -1,4 +1,5 @@
 require "fast_gettext"
+require "logger"
 
 module Yast
   # Provides translation wrapper.
@@ -54,10 +55,8 @@ module Yast
       end
       FastGettext::Translation::_ str
     rescue Errno::ENOENT => error
-      if defined?(log) && log.respond_to?(:warn)
-        log.warn("File not found when translating '#{str}' on textdomain #{@my_textdomain}'. "\
-                 "Error: #{error}. Backtrace: #{error.backtrace}")
-      end
+      Yast.y2warning("File not found when translating '#{str}' on textdomain #{@my_textdomain}'. "\
+        "Error: #{error}. Backtrace: #{error.backtrace}")
       str
     end
 
@@ -117,10 +116,8 @@ module Yast
       end
       FastGettext::Translation::n_(singular, plural, num)
     rescue Errno::ENOENT => error
-      if defined?(log) && log.respond_to?(:warn)
-        log.warn("File not found when translating '#{singular}/#{plural}' with '#{num}' "\
-          "on textdomain #{@my_textdomain}'. Error: #{error}. Backtrace: #{error.backtrace}")
-      end
+      Yast.y2warning("File not found when translating '#{singular}/#{plural}' with '#{num}' "\
+        "on textdomain #{@my_textdomain}'. Error: #{error}. Backtrace: #{error.backtrace}")
       fallback_n_(singular, plural, num)
     end
 

--- a/tests/ruby/i18n_spec.rb
+++ b/tests/ruby/i18n_spec.rb
@@ -1,5 +1,4 @@
 #!/usr/bin/env rspec
-# coding: utf-8
 
 require_relative "test_helper"
 
@@ -33,10 +32,13 @@ module Yast
       PLURAL = "plural".freeze
 
       before do
+        allow(File).to receive(:exist?).with(Yast::I18n::LOCALE_DIR)
+          .and_return(true)
         textdomain("base")
       end
 
       it "returns the translated string" do
+        allow(FastGettext).to receive(:key_exist?).and_return(true)
         expect(FastGettext::Translation).to receive(:_).with(SINGULAR)
           .and_return(TRANSLATED)
         expect(_(SINGULAR)).to eq(TRANSLATED)
@@ -53,7 +55,7 @@ module Yast
         end
 
         it "logs a warning message" do
-          expect(Yast).to receive(:y2warning)
+          expect(Yast).to receive(:y2warning).at_least(1)
             .with(/File not found/)
           _(SINGULAR)
         end
@@ -62,10 +64,14 @@ module Yast
 
     describe ".n_" do
       before do
+        allow(File).to receive(:exist?).with(Yast::I18n::LOCALE_DIR)
+          .and_return(true)
         textdomain("base")
       end
 
       it "returns the translated string" do
+        allow(FastGettext).to receive(:cached_plural_find)
+          .and_return(true)
         expect(FastGettext::Translation).to receive(:n_)
           .with(SINGULAR, PLURAL, 1).and_return(TRANSLATED)
         expect(n_(SINGULAR, PLURAL, 1)).to eq(TRANSLATED)
@@ -86,7 +92,7 @@ module Yast
         end
 
         it "logs a warning message" do
-          expect(Yast).to receive(:y2warning)
+          expect(Yast).to receive(:y2warning).at_least(1)
             .with(/File not found/)
           expect(n_(SINGULAR, PLURAL, 1)).to eq(SINGULAR)
         end


### PR DESCRIPTION
Try to be more robust to avoid [bsc#1014458](https://bugzilla.suse.com/show_bug.cgi?id=1014458).

It looks like the problem is related to the update of fast_gettext. Once that package has been updated, the`/usr/lib64/ruby/gems/2.1.0/gems/fast_gettext-0.8.1/lib/fast_gettext/vendor/empty.mo` does not exist anymore (now is `/usr/lib64/ruby/gems/2.1.0/gems/fast_gettext-0.9.2/lib/fast_gettext/vendor/empty.mo`).

I think that the crash comes from [this line](https://github.com/grosser/fast_gettext/blob/fa8da8d6947108955450b1d0b515e32a36ee5c38/lib/fast_gettext/translation_repository/mo.rb#L41) which calls [MoFile.empty](https://github.com/grosser/fast_gettext/blob/fa8da8d6947108955450b1d0b515e32a36ee5c38/lib/fast_gettext/mo_file.rb#L39).

I haven't been able to reproduce it, but I think that this patch should solve the potential issue. I want to write some tests but I would like to have some early feedback.