### PR TITLE
Display output of failed headless integration tests

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Mar  9 15:57:00 UTC 2017 - ancor@suse.com
+
+- Display standard output and error channels in case of failure
+  running the Ncurses integration tests in a headless system.
+- 3.2.6
+
+-------------------------------------------------------------------
 Mon Jan  9 14:18:30 UTC 2017 - jreidinger@suse.com
 
 - allow in Yast::SCR and Yast::WFM to have string as first

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -3,6 +3,7 @@ Thu Mar  9 15:57:00 UTC 2017 - ancor@suse.com
 
 - Display standard output and error channels in case of failure
   running the Ncurses integration tests in a headless system.
+  Needed to debug the error produced by the fix to bsc#1021743
 - 3.2.6
 
 -------------------------------------------------------------------

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.2.5
+Version:        3.2.6
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/tests/integration/run.rb
+++ b/tests/integration/run.rb
@@ -7,14 +7,29 @@
 #   rspec std_streams_spec.rb
 # but headless systems like jenkins need this script to fake the screen
 
-test = File.dirname(__FILE__) + "/std_streams_spec.rb"
-cmd = "rspec #{test}"
+RESULT = "/tmp/exit".freeze
+OUTPUT = "/tmp/test_cmd_output".freeze
 
-`screen -D -m sh -c '#{cmd}; echo \$? > /tmp/exit'`
-if File.read("/tmp/exit") != "0\n"
-  puts "Test failed: '#{cmd}'. Rerun manually to see the cause."
-  exit false
-else
+def cleanup
+  [RESULT, OUTPUT].each do |file|
+    File.delete(file) if File.exist?(file)
+  end
+end
+
+test = File.dirname(__FILE__) + "/std_streams_spec.rb"
+cmd = "rspec #{test} >#{OUTPUT} 2>&1"
+
+`screen -D -m sh -c '#{cmd}; echo \$? > #{RESULT}'`
+if File.exist?(RESULT) && File.read(RESULT) == "0\n"
   puts "Test succeeded."
+  cleanup
   exit true
+else
+  puts "Test failed: '#{cmd}'."
+  if File.exist?(OUTPUT)
+    puts "Output was:"
+    puts File.read(OUTPUT)
+  end
+  cleanup
+  exit false
 end


### PR DESCRIPTION
Trying to figure out what's going on here https://build.opensuse.org/request/show/460505 since it cannot be reproduced out of OBS.