### PR TITLE
Nicer backtrace

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Sep 26 13:20:14 UTC 2017 - jreidinger@suse.com
+
+- Nicer backtrace output in log for internal errors (help for
+  debuggging bugs like bsc#1044312)
+- 4.0.0
+
+-------------------------------------------------------------------
 Wed Jul 12 09:33:56 UTC 2017 - jreidinger@suse.com
 
 - Always use ::Integer to avoid collision with Yast::Integer

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.3.1
+Version:        4.0.0
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -243,17 +243,17 @@ module Yast
       Yast.import "Report"
       Report.Error(msg)
     rescue Exception => e
-      Builtins.y2internal("Error reporting failed with '%1' and backtrace %2",
+      Builtins.y2internal("Error reporting failed with '%1'.\n Backtrace:\n%2",
         e.message,
-        e.backtrace)
+        e.backtrace.join("\n"))
     end
 
     # Handles a generic Exception
     private_class_method def self.handle_exception(e, client)
-      Builtins.y2error("Client call failed with '%1' (%2) and backtrace %3",
+      Builtins.y2error("Client call failed with '%1' (%2).\nBacktrace:\n%3",
         e.message,
         e.class,
-        e.backtrace)
+        e.backtrace.join("\n"))
 
       msg = internal_error_msg(e)
 
@@ -275,9 +275,9 @@ module Yast
         Report.Error(msg)
       end
     rescue Exception => e
-      Builtins.y2internal("Error reporting failed with '%1' and backtrace %2",
+      Builtins.y2internal("Error reporting failed with '%1'.Backtrace:\n%2",
         e.message,
-        e.backtrace)
+        e.backtrace.join("\n"))
     end
 
     private_class_method def self.check_client_result_type!(result)


### PR DESCRIPTION
how output now looks like ( with testing client that just raise error ):

```
2017-09-26 15:19:23 <3> pepa(2635) [Ruby] yast/wfm.rb:253 Client call failed with 'funny' (RuntimeError).
Backtrace:
/tmp/test.rb:1:in `<top (required)>'
/usr/lib64/ruby/vendor_ruby/2.4.0/yast/wfm.rb:300:in `eval'
/usr/lib64/ruby/vendor_ruby/2.4.0/yast/wfm.rb:300:in `run_client'
/usr/lib64/ruby/vendor_ruby/2.4.0/yast/wfm.rb:206:in `call_builtin'
/usr/lib64/ruby/vendor_ruby/2.4.0/yast/wfm.rb:206:in `call_builtin_wrapper'
/usr/lib64/ruby/vendor_ruby/2.4.0/yast/wfm.rb:195:in `CallFunction'
/usr/lib/YaST2/bin/y2start:56:in `<main>'
```