### PR TITLE
Log a warning if no text domain is configured (bsc#1081466)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar 27 12:52:27 UTC 2018 - lslezak@suse.cz
+
+- Log a warning if no text domain is configured for translations,
+  this helps with debugging (improved as a part of bsc#1081466)
+- 4.0.5
+
+-------------------------------------------------------------------
 Tue Jan  9 14:41:33 UTC 2018 - jreidinger@suse.com
 
 - Set proper title also for YaST2 scc (bsc#1075164)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.0.4
+Version:        4.0.5
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/i18n.rb
+++ b/src/ruby/yast/i18n.rb
@@ -43,7 +43,11 @@ module Yast
     # translates given string
     def _(str)
       # no textdomain configured yet
-      return str unless @my_textdomain
+      if !@my_textdomain
+        Yast.y2warning("No textdomain configured, cannot translate #{str.inspect}")
+        Yast.y2warning("Called from: #{::Kernel.caller(1).first}")
+        return str
+      end
 
       found = true
       # Switching textdomain clears gettext caches so avoid it if possible.
@@ -99,7 +103,12 @@ module Yast
     # @param (String) plural text for translators for bigger value
     def n_(singular, plural, num)
       # no textdomain configured yet
-      return fallback_n_(singular, plural, num) unless @my_textdomain
+      if !@my_textdomain
+        # it's enough to log just the singular form
+        Yast.y2warning("No textdomain configured, cannot translate text #{singular.inspect}")
+        Yast.y2warning("Called from: #{::Kernel.caller(1).first}")
+        return fallback_n_(singular, plural, num)
+      end
 
       # Switching textdomain clears gettext caches so avoid it if possible.
       # difference between _ and n_ is hat we need special cache for plural forms


### PR DESCRIPTION
- This helps with debugging so the missing `textdomain` calls can be easier found.
- Writing the caller to the log helps to find the place where the translation call was used incorrectly. Grepping the sources for the label is a bit tricky if it contains the `&` shortcut marker or `%s` placeholders.
- 4.0.5

### Example Log

I have tested this when fixing bug https://github.com/yast/yast-network/pull/619, now the problematic place is logged into y2log:

```
2018-03-27 13:31:49 <2> dhcp25(24521) [Ruby] yast/i18n.rb:47 No textdomain configured, ca
nnot translate text "Enable access using a &web browser"
2018-03-27 13:31:49 <2> dhcp25(24521) [Ruby] yast/i18n.rb:48 Called from: /usr/share/YaST
2/lib/y2remote/widgets/remote.rb:165:in `label'
```