### PR TITLE
Fix y2start to return the client return value

### DIFF
--- a/src/y2start/y2start
+++ b/src/y2start/y2start
@@ -55,4 +55,7 @@ title = "YaST2 - #{args[:client_name]}#{hostname}"
 set_title = args[:client_options][:params].empty? || NO_CLI_CLIENTS.include?(args[:client_name])
 Yast::UI.SetApplicationTitle(title) if set_title
 
-Yast::WFM.CallFunction(args[:client_name], args[:client_options][:params])
+ret = Yast::WFM.CallFunction(args[:client_name], args[:client_options][:params])
+if ret == false
+  exit 16
+end

--- a/src/y2start/y2start
+++ b/src/y2start/y2start
@@ -56,5 +56,3 @@ set_title = args[:client_options][:params].empty? || NO_CLI_CLIENTS.include?(arg
 Yast::UI.SetApplicationTitle(title) if set_title
 
 Yast::WFM.CallFunction(args[:client_name], args[:client_options][:params])
-
-0


### PR DESCRIPTION
so that the EXIT STATUS section of `man yast` is again correct

found in https://github.com/yast/yast-network/pull/686