### PR TITLE
Fit long internal error to the screen

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Mar  4 09:11:50 UTC 2019 - Michal Filka <mfilka@suse.com>
+
+- bnc#1127685
+  - Internal error message popup is scaled according to its content
+- 4.1.3
+
+-------------------------------------------------------------------
 Tue Jan 22 17:58:53 UTC 2019 - lslezak@suse.cz
 
 - Support for FastGettext 2.0 (still works with FastGettext 1.6)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.1.2
+Version:        4.1.3
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -216,7 +216,7 @@ module Yast
     # @return [String] human readable exception description
     private_class_method def self.internal_error_msg(e)
       msg = "Internal error. Please report a bug report with logs.\n" \
-        "Run save_y2logs to get complete logs.\n"
+        "Run save_y2logs to get complete logs.\n\n"
 
       if e.is_a?(ArgumentError) && e.message =~ /invalid byte sequence in UTF-8/
         msg += "A string was encountered that is not valid in UTF-8.\n" \
@@ -224,7 +224,7 @@ module Yast
                "Refer to https://www.suse.com/support/kb/doc?id=7018056.\n\n"
       end
 
-      msg + "Details: #{e.message}\n" \
+      msg + "Details: #{e.message}\n\n" \
             "Caller:  #{e.backtrace.first}"
     end
 
@@ -273,7 +273,7 @@ module Yast
         end
       else
         Yast.import "Report"
-        Report.Error(msg)
+        Report.LongError(msg.gsub(/\n/, '<br />')
       end
     rescue Exception => e
       Builtins.y2internal("Error reporting failed with '%1'.Backtrace:\n%2",

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -224,8 +224,8 @@ module Yast
                "Refer to https://www.suse.com/support/kb/doc?id=7018056.\n\n"
       end
 
-      msg + "Details: #{e.message}\n\n" \
-            "Caller:  #{e.backtrace.first}"
+       msg + "Caller:  #{e.backtrace.first}\n\n" \
+             "Details: #{e.message}"
     end
 
     # Handles a SignalExpection
@@ -273,7 +273,12 @@ module Yast
         end
       else
         Yast.import "Report"
-        Report.LongError(msg.gsub(/\n/, '<br />')
+        # Pure approximation here
+        # 50 is for usable text area width, +6 is for additional lines like
+        # button line, Error caption and so. Whole dialog is at most 20 lines
+        # high to fit into screen
+        height = [msg.size / 50 + 6, 20].min
+        Report.LongError(msg.gsub(/\n/, '<br />'), height:height)
       end
     rescue Exception => e
       Builtins.y2internal("Error reporting failed with '%1'.Backtrace:\n%2",


### PR DESCRIPTION
Depends on https://github.com/yast/yast-yast2/pull/899

When an internal error with long backtrace is raised, it gets easily out of popup:
![long_internal_error_before](https://user-images.githubusercontent.com/1579239/53626798-fb97a300-3c06-11e9-9469-f6a7f02ba259.png)
With support for long text it is slightly better:
![long_internal_error_after](https://user-images.githubusercontent.com/1579239/53626816-00f4ed80-3c07-11e9-9abe-95b0f4c9b152.png)
