### PR TITLE
_() should always return a frozen string

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Mar  5 14:23:29 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
+
+- Always return frozen strings from the translation functions,
+  make the results unified (related to bsc#1125006)
+- 4.1.4
+
+-------------------------------------------------------------------
 Mon Mar  4 09:11:50 UTC 2019 - Michal Filka <mfilka@suse.com>
 
 - bnc#1127685

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.1.3
+Version:        4.1.4
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/i18n.rb
+++ b/src/ruby/yast/i18n.rb
@@ -43,12 +43,19 @@ module Yast
     end
 
     # translates given string
+    # @param str [String] the string to translate
+    # @return [String] the translated string, if the translation is not found then
+    #   the original text is returned. **The returned String is frozen!**
+    # @note **⚠ The translated string is frozen and cannot be modified. To provide
+    #   consistent results the original (not translated) string is also frozen.
+    #   This means this function modifies the passed argument! If you do not want this
+    #   behavior then pass a duplicate, e.g. `_(text.dup)`. ⚠**
     def _(str)
       # no textdomain configured yet
       if !@my_textdomain
         Yast.y2warning("No textdomain configured, cannot translate #{str.inspect}")
         Yast.y2warning("Called from: #{::Kernel.caller(1).first}")
-        return str
+        return str.freeze
       end
 
       found = true
@@ -60,7 +67,7 @@ module Yast
           key_exist?(str)
         end
       end
-      found ? Translation._(str) : str
+      found ? Translation._(str) : str.freeze
     end
 
     # No translation, only marks the text to be found by gettext when creating POT file,
@@ -101,8 +108,16 @@ module Yast
     end
 
     # Gets translation based on number.
-    # @param (String) singular text for translators for single value
-    # @param (String) plural text for translators for bigger value
+    # @param [String] singular text for translators for single value
+    # @param [String] plural text for translators for bigger value
+    # @param [String] num the actual number, used for evaluating the correct plural form
+    # @return [String] the translated string, if the translation is not found then
+    #   the original text is returned (either the plural or the singular version,
+    #   depending on the `num` parameter). **The returned String is frozen!**
+    # @note **⚠ The translated string is frozen and cannot be modified. To provide
+    #   consistent results the original (not translated) strings are also frozen.
+    #   This means this function modifies the passed argument! If you do not want this
+    #   behavior then pass a duplicate, e.g. `n_(singular.dup, plural.dup, n)`. ⚠**
     def n_(singular, plural, num)
       # no textdomain configured yet
       if !@my_textdomain
@@ -188,6 +203,10 @@ module Yast
     #
     # @return [String] {singular} if {num} == 1; {plural} otherwise.
     def fallback_n_(singular, plural, num)
+      # always freeze both strings to have consistent results
+      singular.freeze
+      plural.freeze
+
       (num == 1) ? singular : plural
     end
   end

--- a/tests/i18n_spec.rb
+++ b/tests/i18n_spec.rb
@@ -8,6 +8,12 @@ include Yast::I18n
 
 module Yast
   describe I18n do
+
+    before do
+      # do not read the real translations from the system
+      allow(FastGettext).to receive(:add_text_domain)
+    end
+
     describe ".N_" do
       it "returns the original parameter" do
         input = "INPUT TEST"
@@ -41,6 +47,20 @@ module Yast
         expect(Yast::Translation).to receive(:_).with(SINGULAR)
           .and_return(TRANSLATED)
         expect(_(SINGULAR)).to eq(TRANSLATED)
+      end
+
+      context "translation is not found" do
+        it "returns a frozen string if the translation is not found" do
+          allow(FastGettext).to receive(:key_exist?).and_return(false)
+          expect(_("foo")).to be_frozen
+        end
+
+        it "freezes the passed argument string if the translation is not found" do
+          allow(FastGettext).to receive(:key_exist?).and_return(false)
+          text = "foo"
+          _(text)
+          expect(text).to be_frozen
+        end
       end
 
       context "when FastGettext throws an Errno::ENOENT exception" do


### PR DESCRIPTION
*This is a proposal for the fix discussed on yast-devel@ ML, lets continue here.*

## The Problem

The `_()` translation function returns either a frozen String (from FastGettext when the translation is available) or a normal (not frozen) String when the translation is not found.

This makes the code fragile and difficult to debug as `_("foo") << _("bar")` might crash or might not depending whether the translation is available.

The problem is that when running the unit tests in Travis, Jenkins or in OBS no translation is installed and the tests run in the English locale. However, on user systems or during installation the translations are usually available. That means it's hard to test it in the same environment, the unit tests might not find this problem in the code.

Moreover the translations for new texts might be available later, so it could work fine but crash later after updating the translation package without changing the YaST module at all. Or it might crash after switching the language. That's a debugging nightmare...



### Translation Available

```console
> rpm -q yast2-trans-cs
yast2-trans-cs-84.87.20180514.157a0650d-lp150.1.1.noarch
> LC_ALL=cs_CZ.UTF-8 ruby -ryast -e 'include Yast::I18n; textdomain "base"; puts _("&Yes"); puts _("&Yes").frozen?'
&Ano
true
```

The result is a *frozen* translated string.

### Translation Not Available

```console
> rpm -q yast2-trans-es
package yast2-trans-es is not installed
> LC_ALL=es_ES.UTF-8 ruby -ryast -e 'include Yast::I18n; textdomain "base"; puts _("&Yes"); puts _("&Yes").frozen?'
&Yes
false
```

In this case you'll get the original untranslated and *not frozen* string.

## Solution

    found ? Translation._(str) : str.freeze

The fast_gettext gem returns nil when the translation is not available. In that case we return the original text but frozen to behave the same way.

## Disadvantage

The disadvantage is that freezing the String will have an unexpected side effect:

```
foo = N_("foo: ")
puts _(foo)
foo << "bar" # this will crash after freezing foo
```

But as this is just a theoretical and an obscure example which can be fixed by `puts _(foo.dup)` workaround I'm fine with the proposed change.

## Testing

I have tested the proposed patch in a SLE15-SP1 installation and everything was fine.