### PR TITLE
A missing `textdomain` declaration is optionally an exception

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Thu May 16 12:19:59 UTC 2019 - mvidner@suse.com
+
+- Raise (an Internal Error) if no textdomain is declared for
+  a translatable text and Y2STRICTTEXTDOMAIN is in the environment
+  (bsc#1130822)
+- 4.2.0
+
+-------------------------------------------------------------------
 Tue Mar  5 14:23:29 UTC 2019 - Ladislav Slezák <lslezak@suse.cz>
 
 - Always return frozen strings from the translation functions,

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.1.4
+Version:        4.2.0
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/i18n.rb
+++ b/src/ruby/yast/i18n.rb
@@ -53,8 +53,10 @@ module Yast
     def _(str)
       # no textdomain configured yet
       if !@my_textdomain
-        Yast.y2warning("No textdomain configured, cannot translate #{str.inspect}")
-        Yast.y2warning("Called from: #{::Kernel.caller(1).first}")
+        msg = "No textdomain configured in #{self.class}, " \
+              "cannot translate #{str.inspect}"
+        raise msg if ENV["Y2STRICTTEXTDOMAIN"]
+        Yast.y2warning(1, "%1", msg) # skip 1 frame
         return str.freeze
       end
 
@@ -122,8 +124,10 @@ module Yast
       # no textdomain configured yet
       if !@my_textdomain
         # it's enough to log just the singular form
-        Yast.y2warning("No textdomain configured, cannot translate text #{singular.inspect}")
-        Yast.y2warning("Called from: #{::Kernel.caller(1).first}")
+        msg = "No textdomain configured in #{self.class}, " \
+              "cannot translate #{singular.inspect}"
+        raise msg if ENV["Y2STRICTTEXTDOMAIN"]
+        Yast.y2warning(1, "%1", msg) # skip 1 frame
         return fallback_n_(singular, plural, num)
       end
 


### PR DESCRIPTION
In https://bugzilla.suse.com/show_bug.cgi?id=1130822 we have untranslated text in a dialog, even though the translators did work that particular string. The reason is a missing `textdomain` declaration in a class.

This kind of error is a programmer error which should be caught very early during the development or testing, so users should not see them. 
BUT we may have allowed this kind of bugs to creep in over time so it would be a nuisance to start failing in users faces now.
-> Make it opt-in for testing.

The exception is enabled by export Y2STRICTTEXTDOMAIN=1

![no-textdomain](https://user-images.githubusercontent.com/102056/57853785-f2ba7480-77e6-11e9-8a97-d3e967237567.png)
