### PR TITLE
Avoid breaking the build of yast2.rpm (bsc#1130822)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon May 20 09:09:14 UTC 2019 - mvidner@suse.com
+
+- Fixup the textdomain change so that yast2.rpm builds (bsc#1130822)
+- 4.2.1
+
+-------------------------------------------------------------------
 Thu May 16 12:19:59 UTC 2019 - mvidner@suse.com
 
 - Raise (an Internal Error) if no textdomain is declared for

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.2.0
+Version:        4.2.1
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/i18n.rb
+++ b/src/ruby/yast/i18n.rb
@@ -53,10 +53,12 @@ module Yast
     def _(str)
       # no textdomain configured yet
       if !@my_textdomain
-        msg = "No textdomain configured in #{self.class}, " \
-              "cannot translate #{str.inspect}"
-        raise msg if ENV["Y2STRICTTEXTDOMAIN"]
-        Yast.y2warning(1, "%1", msg) # skip 1 frame
+        if File.exist?(LOCALE_DIR)
+          msg = "No textdomain configured in #{self.class}, " \
+                "cannot translate #{str.inspect}"
+          raise msg if ENV["Y2STRICTTEXTDOMAIN"]
+          Yast.y2warning(1, "%1", msg) # skip 1 frame
+        end
         return str.freeze
       end
 
@@ -123,11 +125,13 @@ module Yast
     def n_(singular, plural, num)
       # no textdomain configured yet
       if !@my_textdomain
-        # it's enough to log just the singular form
-        msg = "No textdomain configured in #{self.class}, " \
-              "cannot translate #{singular.inspect}"
-        raise msg if ENV["Y2STRICTTEXTDOMAIN"]
-        Yast.y2warning(1, "%1", msg) # skip 1 frame
+        if File.exist?(LOCALE_DIR)
+          # it's enough to log just the singular form
+          msg = "No textdomain configured in #{self.class}, " \
+                "cannot translate #{singular.inspect}"
+          raise msg if ENV["Y2STRICTTEXTDOMAIN"]
+          Yast.y2warning(1, "%1", msg) # skip 1 frame
+        end
         return fallback_n_(singular, plural, num)
       end
 


### PR DESCRIPTION
A fixup for #230 - https://bugzilla.suse.com/show_bug.cgi?id=1130822#c13

If /usr/share/YaST2/locale does not exist (eg. during the building of yast2.rpm) FastGettext will complain. So in that case bail out of `textdomain` and `_`+friends.
    
Here's how it broke without this fix:
    
+Log	No textdomain configured in Yast::CommandLineClass, cannot translate "Print the help for this module"

The log line *appears* because it is now reported at CommandLine.rb
(previously i18n.rb) which matches the "testedfiles" filter of the
testsuite.

The error *happens* the "textdomain" method returns early before
remembering its argument.