### PR TITLE
New Ui Widget

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Nov  6 11:32:29 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added symbol for new UI CustomStatusItemSelector widget
+  (bsc#1084674)
+- Added symbol for UI icon term
+- 4.2.4
+
+-------------------------------------------------------------------
 Mon Sep 23 12:13:53 UTC 2019 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added symbols for new UI ItemSelector widget (bsc#1084674)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.2.3
+Version:        4.2.4
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/ui_shortcuts.rb
+++ b/src/ruby/yast/ui_shortcuts.rb
@@ -15,6 +15,7 @@ module Yast
       :CheckBoxFrame,
       :ColoredLabel,
       :ComboBox,
+      :CustomStatusItemSelector,
       :DateField,
       :DownloadProgress,
       :DumbTab,
@@ -78,6 +79,7 @@ module Yast
       :VWeight,
       :Wizard,
       # special ones that will be upper cased
+      :icon,
       :id,
       :item,
       :header,


### PR DESCRIPTION
## Trello

https://trello.com/c/dcDDFwGy/1405-5-allow-additional-status-values-in-multiitemselector

## Description

This adds the new `CustomStatusItemSelector` widget as well as the old `icon` term that for some reason was never added to those UI shortcuts, always making a pretty ugly `term(:icon("iconName"))` necessary.