### PR TITLE
Exit codes

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Tue Dec 17 14:48:01 UTC 2019 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix returning error codes from y2start start point. Helps with
+  CLI exit codes and also with failed installation (helps e.g. with
+  bsc#1144351 and yast lan CLI)
+- 4.2.6
+
+-------------------------------------------------------------------
 Thu Dec  5 10:37:29 CET 2019 - schubi@suse.de
 
 - S390: Evaluating an architecture specific string which will be

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.2.5
+Version:        4.2.6
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -98,6 +98,30 @@ module Yast
       left_title + architecture.rjust(80-left_title.size)
     end
 
+
+    # client returned special result, this is used as offset (or as generic error)
+    RES_CLIENT_RESULT = 16
+    # yast succeed
+    RES_OK = 0
+    # Symbols representing failure
+    FAILED_SYMBOLS = [:abort, :cancel]
+    # transform various ruby objects to exit code. Useful to detection if YaST process failed
+    # and in CLI
+    def self.generate_exit_code(value)
+      case value
+      when nil, true
+        RES_OK
+      when false
+        RES_CLIENT_RESULT
+      when Integer
+        RES_CLIENT_RESULT + value
+      when Symbol
+        FAILED_SYMBOLS.include?(value) ? RES_CLIENT_RESULT : RES_OK
+      else
+        RES_OK
+      end
+    end
+
     private_class_method def self.read_values
       arch = `/usr/bin/read_values -c`.strip
       return "" unless $?.success?

--- a/src/y2start/y2start
+++ b/src/y2start/y2start
@@ -55,6 +55,7 @@ set_title = args[:client_options][:params].empty? || NO_CLI_CLIENTS.include?(arg
 Yast::UI.SetApplicationTitle(
   Yast::Y2StartHelpers.application_title(args[:client_name])) if set_title
 
-Yast::WFM.CallFunction(args[:client_name], args[:client_options][:params])
 
-0
+Yast::Y2StartHelpers.generate_exit_code(
+  Yast::WFM.CallFunction(args[:client_name], args[:client_options][:params])
+)

--- a/tests/integration/run.rb
+++ b/tests/integration/run.rb
@@ -36,6 +36,7 @@ if File.exist?(RESULT) && File.read(RESULT) == "0\n"
   exit true
 else
   puts "Test failed: '#{cmd}'."
+  puts "result: #{File.exist?(RESULT) ? "'#{File.read(RESULT)}'" : "file not exist"}"
   if File.exist?(OUTPUT)
     puts "Output was:"
     puts File.read(OUTPUT)

--- a/tests/y2start_helpers_spec.rb
+++ b/tests/y2start_helpers_spec.rb
@@ -107,4 +107,34 @@ describe Yast::Y2StartHelpers do
     end
   end
 
+  describe ".generate_exit_code" do
+    it "returns 0 for nil" do
+      expect(subject.generate_exit_code(nil)).to eq 0
+    end
+
+    it "returns 0 for true" do
+      expect(subject.generate_exit_code(true)).to eq 0
+    end
+
+    it "returns 16 for false" do
+      expect(subject.generate_exit_code(false)).to eq 16
+    end
+
+    it "returns 16 for `:abort`" do
+      expect(subject.generate_exit_code(:abort)).to eq 16
+    end
+
+    it "returns 16 for `:cancel`" do
+      expect(subject.generate_exit_code(:cancel)).to eq 16
+    end
+
+    it "returns 0 for other symbols" do
+      expect(subject.generate_exit_code(:test)).to eq 0
+    end
+
+    it "returns 16+number for number" do
+      expect(subject.generate_exit_code(1)).to eq 17
+      expect(subject.generate_exit_code(3)).to eq 19
+    end
+  end
 end


### PR DESCRIPTION
Implement proper exit codes of yast program

It is currently identical behavior as in original y2core.
References:
https://github.com/yast/yast-core/blob/master/liby2/src/genericfrontend.cc#L777
https://github.com/yast/yast-core/blob/master/liby2/src/include/y2/exitcodes.h#L25
https://github.com/yast/yast-core/blob/master/liby2/src/genericfrontend.cc#L115

replaces https://github.com/yast/yast-ruby-bindings/pull/222