### PR TITLE
Fixes for gensalt handling with libxcrypt.

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 19:46:00 UTC 2020 - besser82@fedoraproject.org
+
+- Fixes for gensalt handling with libxcrypt
+- 4.2.9
+
+-------------------------------------------------------------------
 Wed Jan 22 15:04:11 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
 - Added a COPYING file with the GPL license (bsc#1161470)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.2.8
+Version:        4.2.9
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Builtin.cc
+++ b/src/binary/Builtin.cc
@@ -223,8 +223,14 @@ extern "C" {
   static char*
   make_crypt_salt (const char* crypt_prefix, int crypt_rounds)
   {
+#ifndef CRYPT_GENSALT_OUTPUT_SIZE
 #define CRYPT_GENSALT_OUTPUT_SIZE (7 + 22 + 1)
+#endif
 
+#ifdef CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY
+    const char *entropy = NULL;
+    const size_t entropy_len = 0;
+#else
 #ifndef RANDOM_DEVICE
 #define RANDOM_DEVICE "/dev/urandom"
 #endif
@@ -238,7 +244,8 @@ extern "C" {
     }
 
     char entropy[16];
-    if (read_loop (fd, entropy, sizeof(entropy)) != sizeof(entropy))
+    const size_t entropy_len = sizeof(entropy);
+    if (read_loop (fd, entropy, entropy_len) != entropy_len)
     {
       close (fd);
       y2error ("Unable to obtain entropy from %s\n", RANDOM_DEVICE);
@@ -246,12 +253,15 @@ extern "C" {
     }
 
     close (fd);
+#endif
 
     char output[CRYPT_GENSALT_OUTPUT_SIZE];
     char* retval = crypt_gensalt_rn (crypt_prefix, crypt_rounds, entropy,
-      sizeof(entropy), output, sizeof(output));
+      entropy_len, output, sizeof(output));
 
-    memset (entropy, 0, sizeof (entropy));
+#ifndef CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY
+    memset (entropy, 0, entropy_len);
+#endif
 
     if (!retval)
     {
@@ -261,6 +271,7 @@ extern "C" {
 
     return strdup (retval);
   }
+
 
   // the return value should be free'd
   char *


### PR DESCRIPTION
The `libxcrypt` library in version >= 4 offers support for safely generating entropy itself.  Besides that, the `<crypt.h>` header of the library already defines `CRYPT_GENSALT_OUTPUT_SIZE`.