### PR TITLE
Fix enc loading

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  2 15:21:20 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- fix gems loading with updated ruby (bsc#1172275)
+- 3.1.53
+
+-------------------------------------------------------------------
 Thu Dec 15 16:29:13 UTC 2016 - igonzalezsosa@suse.com
 
 - Do not crash when FastGettext is unable to find the empty.mo

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.1.52
+Version:        3.1.53
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/YRuby.cc
+++ b/src/binary/YRuby.cc
@@ -72,6 +72,9 @@ YRuby::YRuby()
   if (rb_eval_string("defined? Gem") == Qnil) // Dirty hack to recognize we run from YaST and not ruby
   {
     _y_in_yast = true;
+    // encoding initialization
+    rb_enc_find_index("encdb");
+
     // FIX for setup gem load path. Embedded ruby initialization mixes up gem
     // initialization (which we want) with option processing (which we don't want).
     // Copying only needed parts of `ruby_options` here.
@@ -79,11 +82,6 @@ YRuby::YRuby()
     // Note that the solution is different to not touch internal ruby
     rb_define_module("Gem");
     y2_require("rubygems");
-
-    // encoding initialization
-    y2_require("enc/encdb.so");
-    y2_require("enc/trans/transdb.so");
-    rb_enc_find_index("encdb");
   }
 
   VALUE ycp_references = Data_Wrap_Struct(rb_cObject, gc_mark, gc_free, & value_references_from_ycp);


### PR DESCRIPTION
Fix is needed for MU of ruby on SLE12 SP2. See https://bugzilla.suse.com/show_bug.cgi?id=1172275 for references. Patch was provided by @darix

Change for newer SP is not needed as we start using y2start from SP3.