### PR TITLE
Backport to SLE-12-SP4: Fix Gem Loading

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jun 25 12:40:48 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Backported jreidinger's patches to SLE-12-SP4 (bsc#1172848):
+  - PR#242: Fix enc loading
+    (fix gems loading with updated ruby (bsc#1172275))
+  - PR#243: set also script name
+- 3.2.17
+
+-------------------------------------------------------------------
 Tue Oct 23 09:52:53 UTC 2018 - jreidinger@suse.com
 
 - Fix encoding-related problems by assuming that file contents is

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.2.16
+Version:        3.2.17
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/YRuby.cc
+++ b/src/binary/YRuby.cc
@@ -74,6 +74,8 @@ YRuby::YRuby()
     _y_in_yast = true;
     // encoding initialization
     rb_enc_find_index("encdb");
+    // set in ruby script name (bsc#1172275)
+    ruby_set_script_name(rb_str_new2("yast2"));
 
     // FIX for setup gem load path. Embedded ruby initialization mixes up gem
     // initialization (which we want) with option processing (which we don't want).

--- a/src/binary/YRuby.cc
+++ b/src/binary/YRuby.cc
@@ -72,6 +72,9 @@ YRuby::YRuby()
   if (rb_eval_string("defined? Gem") == Qnil) // Dirty hack to recognize we run from YaST and not ruby
   {
     _y_in_yast = true;
+    // encoding initialization
+    rb_enc_find_index("encdb");
+
     // FIX for setup gem load path. Embedded ruby initialization mixes up gem
     // initialization (which we want) with option processing (which we don't want).
     // Copying only needed parts of `ruby_options` here.
@@ -79,11 +82,6 @@ YRuby::YRuby()
     // Note that the solution is different to not touch internal ruby
     rb_define_module("Gem");
     y2_require("rubygems");
-
-    // encoding initialization
-    y2_require("enc/encdb.so");
-    y2_require("enc/trans/transdb.so");
-    rb_enc_find_index("encdb");
   }
 
   VALUE ycp_references = Data_Wrap_Struct(rb_cObject, gc_mark, gc_free, & value_references_from_ycp);


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1172848

## Trello

https://trello.com/c/tZ9MKejZ/

## Problem

An appliance made with SUSE Studio (i.e. using KIWI) based on SLE-12-SP4 fails since the last Ruby security update in their yast-firstboot step where they do various configurations after extracting their image.

It turned out that they are invoking other YaST modules (e.g. network) as external processes by invoking `y2base` directly.

## Underlying Problems

Ruby does not really have an API for embedding; to integrate it into YaST, we really hammered it into shape to make it work. That involved loading some Ruby gems early upon YaST startup: E.g. the `fast_gettext` gem which we use for translations. How this is done tends to differ slightly between individual Ruby versions, so it has to be adapted when that happens.

## Solution

- Backported some changes that @jreidinger had already made for SLE-12-SP2: https://github.com/yast/yast-ruby-bindings/pull/242, https://github.com/yast/yast-ruby-bindings/pull/243. This is what this PR is all about.

- Recommended to the team who makes that appliance to use the `/sbin/yast` script because this is less fragile; some initializations are done there. Calling `y2base` is subtly different; or call the Ruby code directly from Ruby and not as an external process.

## Screenshots

### Without Patches: Fail

![y2base-vs-y2start](https://user-images.githubusercontent.com/11538225/85744943-93c37080-b705-11ea-813c-67a653ecfd31.png)

Invoking `y2base` makes the called YaST module fail with exit code 16.
Invoking the same with `yast2` works fine.

### With Patches: Success

![with-backport](https://user-images.githubusercontent.com/11538225/85745165-c53c3c00-b705-11ea-8feb-0019c63e9d2f.png)

With the version from this PR, it works even with `y2base`.


## Version number

The source code for those ruby-bindings has not changed at all between SLE-12-SP4, so both will get version 3.2.17.

We discussed this in IRC, and both @lslezak and @jreidinger agree.

## Related PR

This will also go to SLE-12-SP5.