### PR TITLE
Backport to SLE-12-SP5

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
-Thu Jun 25 12:40:48 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+Mon Jun 29 09:59:33 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
-- Backported jreidinger's patches to SLE-12-SP4 (bsc#1172848):
+- Backported jreidinger's patches to SLE-12-SP5 (bsc#1172848):
   - PR#242: Fix enc loading
     (fix gems loading with updated ruby (bsc#1172275))
   - PR#243: set also script name

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Jun 25 12:40:48 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Backported jreidinger's patches to SLE-12-SP4 (bsc#1172848):
+  - PR#242: Fix enc loading
+    (fix gems loading with updated ruby (bsc#1172275))
+  - PR#243: set also script name
+- 3.2.17
+
+-------------------------------------------------------------------
 Tue Oct 23 09:52:53 UTC 2018 - jreidinger@suse.com
 
 - Fix encoding-related problems by assuming that file contents is

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.2.16
+Version:        3.2.17
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/YRuby.cc
+++ b/src/binary/YRuby.cc
@@ -72,6 +72,11 @@ YRuby::YRuby()
   if (rb_eval_string("defined? Gem") == Qnil) // Dirty hack to recognize we run from YaST and not ruby
   {
     _y_in_yast = true;
+    // encoding initialization
+    rb_enc_find_index("encdb");
+    // set in ruby script name (bsc#1172275)
+    ruby_set_script_name(rb_str_new2("yast2"));
+
     // FIX for setup gem load path. Embedded ruby initialization mixes up gem
     // initialization (which we want) with option processing (which we don't want).
     // Copying only needed parts of `ruby_options` here.
@@ -79,11 +84,6 @@ YRuby::YRuby()
     // Note that the solution is different to not touch internal ruby
     rb_define_module("Gem");
     y2_require("rubygems");
-
-    // encoding initialization
-    y2_require("enc/encdb.so");
-    y2_require("enc/trans/transdb.so");
-    rb_enc_find_index("encdb");
   }
 
   VALUE ycp_references = Data_Wrap_Struct(rb_cObject, gc_mark, gc_free, & value_references_from_ycp);


### PR DESCRIPTION
**This is the SLE-12-SP5 version of PR https://github.com/yast/yast-ruby-bindings/pull/244**.

Refer to https://github.com/yast/yast-ruby-bindings/pull/244 for details.