### PR TITLE
Port from SP2 to SP3 of the fix for newer versions of Ruby

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,7 +1,8 @@
 -------------------------------------------------------------------
-Tue Jun  2 15:21:20 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+Tue Aug  4 12:09:58 UTC 2020 - Ancor Gonzalez Sosa <ancor@suse.com>
 
-- fix gems loading with updated ruby (bsc#1172275)
+- Ported jreidinger's patches from SLE-12-SP2: fix gems loading
+  with updated ruby (bsc#1172275, bsc#1172848)
 - 3.2.16
 
 -------------------------------------------------------------------

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue Jun  2 15:21:20 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
+
+- fix gems loading with updated ruby (bsc#1172275)
+- 3.2.16
+
+-------------------------------------------------------------------
 Tue Dec  5 15:57:34 UTC 2017 - jreidinger@suse.com
 
 - Set proper title also for YaST2 Firstboot (bsc#1070583)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.2.15
+Version:        3.2.16
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/YRuby.cc
+++ b/src/binary/YRuby.cc
@@ -72,6 +72,11 @@ YRuby::YRuby()
   if (rb_eval_string("defined? Gem") == Qnil) // Dirty hack to recognize we run from YaST and not ruby
   {
     _y_in_yast = true;
+    // encoding initialization
+    rb_enc_find_index("encdb");
+    // set in ruby script name (bsc#1172275)
+    ruby_set_script_name(rb_str_new2("yast2"));
+
     // FIX for setup gem load path. Embedded ruby initialization mixes up gem
     // initialization (which we want) with option processing (which we don't want).
     // Copying only needed parts of `ruby_options` here.
@@ -79,11 +84,6 @@ YRuby::YRuby()
     // Note that the solution is different to not touch internal ruby
     rb_define_module("Gem");
     y2_require("rubygems");
-
-    // encoding initialization
-    y2_require("enc/encdb.so");
-    y2_require("enc/trans/transdb.so");
-    rb_enc_find_index("encdb");
   }
 
   VALUE ycp_references = Data_Wrap_Struct(rb_cObject, gc_mark, gc_free, & value_references_from_ycp);


### PR DESCRIPTION
A security fix for Ruby was released for SLE-12-SP2, SP3, SP4 and SP5... that broke YaST.

The fix for SP2 was introduced in #242 and #243. The original plan was to not port that fix to the SLE-12-SP3 branch. But after some discussions in [bsc#1172848](https://bugzilla.suse.com/show_bug.cgi?id=1172848), it was decided to make it available for SLE-12-SP3-LTSS.

Tested manually in a SLE-12-SP3-LTSS. Verified it indeed fixes the problem.