### PR TITLE
New Widget: MenuBar

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Aug 12 11:53:05 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added new UI terms: MenuBar(), Menu() (bsc#1175115)
+- 4.3.1
+
+-------------------------------------------------------------------
 Wed Apr 22 06:48:52 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - reimplement Builtins#tointeger to not use scanf removed from ruby

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.0
+Version:        4.3.1
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -40,9 +40,9 @@ Requires:       rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
 BuildRequires:  ruby-devel
 Requires:       yast2-core >= 3.2.2
 BuildRequires:  yast2-core-devel >= 3.2.2
-# UI.SetApplicationTitle
-Requires:       yast2-ycp-ui-bindings       >= 4.2.2
-BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.2.2
+# MenuBar widget
+Requires:       yast2-ycp-ui-bindings       >= 4.3.11
+BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.11
 # The test suite includes a regression test (std_streams_spec.rb) for a
 # libyui-ncurses bug fixed in 2.47.3
 BuildRequires:  libyui-ncurses >= 2.47.3

--- a/src/ruby/yast/ui_shortcuts.rb
+++ b/src/ruby/yast/ui_shortcuts.rb
@@ -4,6 +4,7 @@ module Yast
   # Module that provides shortcuts for known UI terms, so UI can be constructed in nice way.
   module UIShortcuts
     # Define symbols for the UI
+    # See https://github.com/libyui/libyui/blob/master/src/YUISymbols.h
     UI_TERMS = [
       :BarGraph,
       :BusyIndicator,
@@ -42,6 +43,7 @@ module Yast
       :Left,
       :LogView,
       :MarginBox,
+      :MenuBar,
       :MenuButton,
       :MinHeight,
       :MinSize,
@@ -83,6 +85,7 @@ module Yast
       :id,
       :item,
       :header,
+      :menu,
       :opt
     ].freeze
 


### PR DESCRIPTION
## Trello

https://trello.com/c/4GtDpmMo/1956-5-menu-bar-widget

## Overview

This adds some new UI terms to the Ruby bindings:

- `MenuBar(...)`
- `Menu(...)`

Alternatively, it was (and is) also possible to use

```Ruby
term(:MenuBar, ...)
```

```Ruby
term(:menu, ...)
```

But having the terms directly makes the code cleaner and better readable.

## Master PR

https://github.com/libyui/libyui/pull/169