### PR TITLE
Crypt improvements

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,5 +1,5 @@
 -------------------------------------------------------------------
-Wed Feb 26 19:46:00 UTC 2020 - besser82@fedoraproject.org
+Thu Sep 24 19:46:00 UTC 2020 - besser82@fedoraproject.org
 
 - Fixes for gensalt handling with libxcrypt (bsc#1176924)
 - 4.3.4

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Wed Feb 26 19:46:00 UTC 2020 - besser82@fedoraproject.org
+
+- Fixes for gensalt handling with libxcrypt (bsc#1176924)
+- 4.3.4
+
+-------------------------------------------------------------------
 Wed Sep 23 12:00:57 UTC 2020 - Josef Reidinger <jreidinger@suse.com>
 
 - Improve logger to log also method name in ruby (useful for any

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.3
+Version:        4.3.4
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Builtin.cc
+++ b/src/binary/Builtin.cc
@@ -223,8 +223,14 @@ extern "C" {
   static char*
   make_crypt_salt (const char* crypt_prefix, int crypt_rounds)
   {
+#ifndef CRYPT_GENSALT_OUTPUT_SIZE
 #define CRYPT_GENSALT_OUTPUT_SIZE (7 + 22 + 1)
+#endif
 
+#ifdef CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY
+    const char *entropy = NULL;
+    const size_t entropy_len = 0;
+#else
 #ifndef RANDOM_DEVICE
 #define RANDOM_DEVICE "/dev/urandom"
 #endif
@@ -238,7 +244,8 @@ extern "C" {
     }
 
     char entropy[16];
-    if (read_loop (fd, entropy, sizeof(entropy)) != sizeof(entropy))
+    const size_t entropy_len = sizeof(entropy);
+    if (read_loop (fd, entropy, entropy_len) != entropy_len)
     {
       close (fd);
       y2error ("Unable to obtain entropy from %s\n", RANDOM_DEVICE);
@@ -246,12 +253,15 @@ extern "C" {
     }
 
     close (fd);
+#endif
 
     char output[CRYPT_GENSALT_OUTPUT_SIZE];
     char* retval = crypt_gensalt_rn (crypt_prefix, crypt_rounds, entropy,
-      sizeof(entropy), output, sizeof(output));
+      entropy_len, output, sizeof(output));
 
-    memset (entropy, 0, sizeof (entropy));
+#ifndef CRYPT_GENSALT_IMPLEMENTS_AUTO_ENTROPY
+    memset (entropy, 0, entropy_len);
+#endif
 
     if (!retval)
     {
@@ -261,6 +271,7 @@ extern "C" {
 
     return strdup (retval);
   }
+
 
   // the return value should be free'd
   char *

--- a/tests/builtins_spec.rb
+++ b/tests/builtins_spec.rb
@@ -560,11 +560,6 @@ describe Yast::Builtins do
     it "works as expected" do
       suffixes = ["", "md5", "blowfish", "sha256", "sha512"]
 
-      # FIXME: Travis hack: skip some tests, only standard crypt and MD5 algorithms
-      # work in Ubuntu, it uses a different cprypto setup in glibc,
-      # cannot be easily fixed :-(
-      suffixes = suffixes[0, 2] if ENV["TRAVIS"]
-
       suffixes.each do |suffix|
         res = Yast::Builtins.send(:"crypt#{suffix}", "test")
         # crypt result is salted and cannot be reproduced


### PR DESCRIPTION
follow up of https://github.com/yast/yast-ruby-bindings/pull/239
I clean this up to support only the latest libxcrypt as it is already in SLE15 SP3, Leap 15.3 and TW.
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1176924