### PR TITLE
Fixed if statement in yast2-ruby-bindings.spec

### DIFF
--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -28,7 +28,7 @@ BuildRequires:  cmake
 BuildRequires:  gcc-c++
 BuildRequires:  yast2-core-devel
 BuildRequires:  yast2-devtools >= 3.1.10
-%if 0%{suse_version} == 1310
+%if 0%{?suse_version} == 1310
 BuildRequires:  rubygem-fast_gettext < 3.0
 BuildRequires:  rubygem-rspec
 Requires:       rubygem-fast_gettext < 3.0


### PR DESCRIPTION
rpmbuild fails without the fix. Corrected if statement to work with rpmbuild.