### PR TITLE
WIP: UI Unit Tests for MultiSelectionBox

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Oct 29 17:26:31 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Added unit tests for NCMultiSelectionBox (bsc#1177985)
+- 4.3.6
+
+-------------------------------------------------------------------
 Tue Oct 13 14:42:52 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Add automatic TUI (ncurses) tests using tmux (bsc#1165388).

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.5
+Version:        4.3.6
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -40,9 +40,9 @@ Requires:       rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
 BuildRequires:  ruby-devel
 Requires:       yast2-core >= 3.2.2
 BuildRequires:  yast2-core-devel >= 3.2.2
-# MenuBar widget
-Requires:       yast2-ycp-ui-bindings       >= 4.3.1
-BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.1
+# MultiSelectionBox-test.rb
+Requires:       yast2-ycp-ui-bindings       >= 4.3.5
+BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.5
 # The test suite includes a regression test (std_streams_spec.rb) for a
 # libyui-ncurses bug fixed in 2.47.3
 BuildRequires:  libyui-ncurses >= 2.47.3

--- a/tests/libyui/multi_selection_box_spec.rb
+++ b/tests/libyui/multi_selection_box_spec.rb
@@ -1,37 +1,115 @@
 require_relative "rspec_tmux_tui"
 
 describe "MultiSelectionBox" do
-  bug = "1177760" # https://bugzilla.suse.com/show_bug.cgi?id=1177982
+  context "Basics" do
+    before(:all) do
+      @base = "multi_selection_box_basics"
+      @tui = YastTui.new
+      @tui.example("MultiSelectionBox-test")
+      @tui.await("Select toppings")
+      @tui.capture_pane_to("#{@base}-1")
+    end
 
-  around(:each) do |ex|
-    @base = "multi_selection_box_#{bug}"
-    @tui = YastTui.new
-    @tui.example("MultiSelectionBox3") do
-      ex.run
+    after(:all) do
+      @tui.send_keys "M-C"        # &Close
+    end
+
+    describe "Visual appearance" do
+      it "Has all the expected items" do
+        # the output; //m = match across lines
+        expect(@tui.capture_pane).to match(/Cheese.*Tomatoes.*Mushrooms.*Onions.*Salami.*Ham/m)
+      end
+
+      it "Visually selects the right items initially" do
+        expect(@tui.capture_pane).to include("[x] Cheese", "[x] Tomatoes",
+                                             "[ ] Mushrooms", "[ ] Onions", "[ ] Salami", "[ ] Ham")
+      end
+    end
+
+    describe "Introspection" do
+      it "QueryWidget(:SelectedItems) reports the correct items" do
+        expect(@tui.capture_pane).to match(/Selected:\s+\[:cheese, :tomatoes\]/)
+      end
+
+      it "QueryWidget(:CurrentItem) reports the correct item" do
+        expect(@tui.capture_pane).to match(/Current:\s+:cheese/)
+      end
+    end
+
+    describe "Basic keyboard handling" do
+      it "Moving the cursor works" do
+        @tui.send_keys "M-S"      # &Select toppings
+        @tui.send_keys "Home"     # first item
+        @tui.send_keys "Down"
+        @tui.send_keys "Down"
+        expect(@tui.capture_pane).to match(/Current:\s+:mushrooms/)
+        @tui.send_keys "End"        # last item
+        expect(@tui.capture_pane).to match(/Current:\s+:ham/)
+      end
+
+      it "Selecing an item works visually and in the internal state" do
+        @tui.send_keys "M-S"      # &Select toppings
+        @tui.send_keys "End"      # last item ("Ham")
+        @tui.send_keys "Space"    # select/deselect item
+        expect(@tui.capture_pane).to match(/Selected:\s+\[:cheese, :tomatoes\, :ham\]/)
+        expect(@tui.capture_pane).to include("[x] Ham")
+      end
+
+      it "Deselecting an item works visually and in the internal state" do
+        @tui.send_keys "M-S"      # &Select toppings
+        @tui.send_keys "Home"     # first item
+        @tui.send_keys "Down"     # one item down to "Tomatoes"
+        @tui.send_keys "Space"    # select/deselect item
+        expect(@tui.capture_pane).to match(/Selected:\s+\[:cheese\, :ham\]/)
+        expect(@tui.capture_pane).to include("[ ] Tomatoes")
+      end
+    end
+
+    describe "Exchanging content" do
+      it "Replacing all items works" do
+        expect(@tui.capture_pane).to include("[ ] Vegetarian")
+        @tui.send_keys "M-V"      # &Vegetarian
+        @tui.send_keys "Space"    # toggle combo box
+        @tui.await(/Current:.*:mushrooms/)
+        expect(@tui.capture_pane).to include("[x] Vegetarian")
+        expect(@tui.capture_pane).not_to include("Salami")
+        expect(@tui.capture_pane).not_to include("Ham")
+
+        @tui.send_keys "M-V"      # &Vegetarian
+        @tui.send_keys "Space"    # toggle combo box
+        @tui.await("Salami")
+        expect(@tui.capture_pane).to include("[ ] Vegetarian")
+        expect(@tui.capture_pane).to include("Salami")
+        expect(@tui.capture_pane).to include("Ham")
+      end
     end
   end
 
-  it "ChangeWidget(_, :SelectedItems, _) works, boo##{bug}" do
-    @tui.await("Select pizza toppings")
-    @tui.capture_pane_to("#{@base}-1-initial")
+  context "Known fixed bugs" do
 
-    @tui.send_keys "M-S"        # &Select pizza toppings
-    @tui.send_keys "Home"       # first box item
-    @tui.capture_pane_to("#{@base}-2-box-activated")
+    around(:each) do |ex|
+      @base = "multi_selection_box"
+      @tui = YastTui.new
+      @tui.example("MultiSelectionBox-test") do
+        @tui.await("Select toppings")
+        ex.run
+        @tui.send_keys "M-C"        # &Close
+      end
+    end
 
-    @tui.send_keys "Space"
-    @tui.send_keys "Down"
-    @tui.send_keys "Space"
-    @tui.capture_pane_to("#{@base}-3-two-items-selected")
+    it "bsc#1177985: QueryWidget(:SelectedItems) does not return nil after replacing the items" do
+      @bug = "1177985"       # https://bugzilla.suse.com/show_bug.cgi?id=1177985
 
-    @tui.send_keys "M-O"        # &OK
-    @tui.capture_pane_to("#{@base}-4-report")
+      @tui.send_keys "M-V"      # &Vegetarian
+      @tui.send_keys "Space"    # toggle combo box (this will replace all items)
+      @tui.await(/Current:.*:mushrooms/)
+      @tui.capture_pane_to("#{@base}-#{@bug}")
 
-    # the label
-    @tui.await("Your pizza will come with")
-    # the output; //m = match across lines
-    expect(@tui.capture_pane).to match(/cheese.*tomatoes.*onions.*sausage/m)
-
-    @tui.send_keys "M-O"        # &OK
+      # FIXME: The UI example also selects :mushrooms, but that does not appear
+      # in this rspec environment. Display sync problem? Even a tactical
+      # sleep() does not help, and @tui.await(/Selected.*mushrooms/) times out.
+      # For now, only expecting a non-nil value here.
+      expect(@tui.capture_pane).to match(/Selected:.*:cheese, :tomatoes/)
+    end
   end
 end

--- a/tests/libyui/multi_selection_box_spec.rb
+++ b/tests/libyui/multi_selection_box_spec.rb
@@ -1,0 +1,37 @@
+require_relative "rspec_tmux_tui"
+
+describe "MultiSelectionBox" do
+  bug = "1177760" # https://bugzilla.suse.com/show_bug.cgi?id=1177982
+
+  around(:each) do |ex|
+    @base = "multi_selection_box_#{bug}"
+    @tui = YastTui.new
+    @tui.example("MultiSelectionBox3") do
+      ex.run
+    end
+  end
+
+  it "ChangeWidget(_, :SelectedItems, _) works, boo##{bug}" do
+    @tui.await("Select pizza toppings")
+    @tui.capture_pane_to("#{@base}-1-initial")
+
+    @tui.send_keys "M-S"        # &Select pizza toppings
+    @tui.send_keys "Home"       # first box item
+    @tui.capture_pane_to("#{@base}-2-box-activated")
+
+    @tui.send_keys "Space"
+    @tui.send_keys "Down"
+    @tui.send_keys "Space"
+    @tui.capture_pane_to("#{@base}-3-two-items-selected")
+
+    @tui.send_keys "M-O"        # &OK
+    @tui.capture_pane_to("#{@base}-4-report")
+
+    # the label
+    @tui.await("Your pizza will come with")
+    # the output; //m = match across lines
+    expect(@tui.capture_pane).to match(/cheese.*tomatoes.*onions.*sausage/m)
+
+    @tui.send_keys "M-O"        # &OK
+  end
+end

--- a/tests/libyui/rspec_tmux_tui.rb
+++ b/tests/libyui/rspec_tmux_tui.rb
@@ -70,13 +70,18 @@ class TmuxTui
     File.write("#{filename}.out.esc", esc)
   end
 
+  # Wait about 10 seconds for *pattern* to appear.
+  # @param pattern [String,Regexp] a literal String or a regular expression
+  # @raise [Error] if it does not appear
+  # @return [void]
   def await(pattern)
+    pattern = Regexp.new(Regexp.quote(pattern)) if pattern.is_a? String
+
     sleeps = [0.1, 0.2, 0.2, 0.5, 1, 2, 2, 5]
     txt = ""
     sleeps.each do |sl|
       txt = capture_pane
-      case txt
-      when pattern
+      if txt =~ pattern
         sleep 0.1 # draw the rest of the screen
         return nil
       else


### PR DESCRIPTION
## Trello

https://trello.com/c/ZbkIbc0M/2133-3-probable-libyui-regressions-p1-1177985-and-p1-1177982

## New UI Unit Test

This tests some basic features of the MultiSelectionBox as well as the regression that was just fixed in https://github.com/libyui/libyui-ncurses/pull/108 .

It uses this new UI example from https://github.com/libyui/libyui-ncurses/pull/108 :

![MultiSelectionBox-test-ncurses](https://user-images.githubusercontent.com/11538225/97610397-18f0c600-1a15-11eb-84f2-db98028ce82c.png)

https://github.com/yast/yast-ycp-ui-bindings/blob/master/examples/MultiSelectionBox-test.rb

# Problems

- This is not  100% stable. Sometimes some individual tests fail (typically the keyboard handling tests); it appears that this is because of screen update sync problems.

- Probably similar reason: After switching the `[ ] Vegetarian` check box, it should also select one more topping. That works when starting the example interactively, but never in the unit tests. This may also be a sync problem.

**_FIXME: TO DO_**
