### PR TITLE
Distinguish parsing errors from internal errors (bsc#1127906)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Oct 29 11:30:49 UTC 2020 - Stefan Schubert <schubi@suse.com>
+
+- Reporting augeas parsing errors and displaying them in rich-text
+  format (bsc#1174198).
+- 3.2.18
+
+-------------------------------------------------------------------
 Mon Jun 29 09:59:33 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Backported jreidinger's patches to SLE-12-SP5 (bsc#1172848):

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        3.2.17
+Version:        3.2.18
 Url:            https://github.com/yast/yast-ruby-bindings
 Release:        0
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/debugger.rb
+++ b/src/ruby/yast/debugger.rb
@@ -2,6 +2,18 @@
 require "yast"
 
 module Yast
+  # Interface to a Ruby debugger (byebug)
+  #
+  # `Y2DEBUGGER` environment variable (or install boot option)
+  #
+  # - 1: start the debugger when YaST starts;
+  #       in GUI, run an xterm with the debugger client;
+  #       in TUI, tell the user to run the debugger client
+  # - manual: like "1" but always tell the user instead of starting the client
+  # - remote: tell the user to connect from a remote machine. INSECURE!
+  # - 0: do not start the debugger, don't even ask if an exception is raised
+  #
+  # See also https://yastgithubio.readthedocs.io/en/latest/debugging/
   class Debugger
     class << self
       include Yast::Logger
@@ -83,6 +95,11 @@ module Yast
 
         log.info "Debugger set to: #{debug}"
         start(remote: debug == "remote", start_client: debug != "manual")
+      end
+
+      # @return [Boolean] Is the debugger explicitly unwanted even if available
+      def unwanted?
+        env_value == "0"
       end
 
       # is the Ruby debugger installed and can be loaded?

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -6,8 +6,6 @@ require "yast/profiler"
 require "yast/yast"
 require "cgi"
 
-include CGI::Escape
-
 # @private we need it as clients is called in global contenxt
 GLOBAL_WFM_CONTEXT = proc {}
 module Yast
@@ -229,8 +227,8 @@ module Yast
             "<li>YaST made a mistake and wrote invalid syntax earlier." \
             " Please report a YaST bug.</li>" \
             "</ol>"
-      msg + "Caller:  #{escapeHTML(e.backtrace.first)}<br><br>" \
-            "Details: #{escapeHTML(e.message)}"
+      msg + "Caller:  #{CGI::escapeHTML(e.backtrace.first)}<br><br>" \
+            "Details: #{CGI::escapeHTML(e.message)}"
     end
 
     # @param [Exception] e the caught exception
@@ -245,8 +243,8 @@ module Yast
                "Refer to https://www.suse.com/support/kb/doc?id=7018056.<br><br>"
       end
 
-      msg + "Caller:  #{escapeHTML(e.backtrace.first)}<br><br>" \
-            "Details: #{escapeHTML(e.message)}"
+      msg + "Caller:  #{CGI::escapeHTML(e.backtrace.first)}<br><br>" \
+            "Details: #{CGI::escapeHTML(e.message)}"
     end
 
     # Handles a SignalExpection

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -305,7 +305,7 @@ module Yast
         end
       else
         Yast.import "Report"
-        Report.LongError(msg, height: height)
+        Report.LongError(msg)
       end
     rescue Exception => e
       Builtins.y2internal("Error reporting failed with '%1' and backtrace %2",

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -4,6 +4,9 @@ require "yast/ops"
 require "yast/debugger"
 require "yast/profiler"
 require "yast/yast"
+require "cgi"
+
+include CGI::Escape
 
 # @private we need it as clients is called in global contenxt
 GLOBAL_WFM_CONTEXT = proc {}
@@ -208,35 +211,53 @@ module Yast
 
     private_class_method def self.ask_to_run_debugger?
       Yast.import "Mode"
+      !Mode.auto && !Debugger.unwanted? && Debugger.installed?
+    end
 
-      !Mode.auto && Debugger.installed?
+    # @param [CFA::AugeasParsingError] e the caught exception
+    # @return [String] human readable exception description
+    private_class_method def self.parsing_error_msg(e)
+      msg = "Parse error while reading file #{e.file}<br>" \
+            "YaST cannot continue and will quit.<br>" \
+            "<br>" \
+            "Possible causes and remedies:" \
+            "<ol>" \
+            "<li>You made a mistake when changing the file by hand," \
+            " the syntax is invalid. Try reverting the changes.</li>" \
+            "<li>The syntax is in fact valid but YaST does not recognize it." \
+            "  Please report a YaST bug.</li>" \
+            "<li>YaST made a mistake and wrote invalid syntax earlier." \
+            " Please report a YaST bug.</li>" \
+            "</ol>"
+      msg + "Caller:  #{escapeHTML(e.backtrace.first)}<br><br>" \
+            "Details: #{escapeHTML(e.message)}"
     end
 
     # @param [Exception] e the caught exception
     # @return [String] human readable exception description
     private_class_method def self.internal_error_msg(e)
-      msg = "Internal error. Please report a bug report with logs.\n" \
-        "Run save_y2logs to get complete logs.\n"
+      msg = "Internal error. Please report a bug report with logs.<br>" \
+        "Run save_y2logs to get complete logs.<br><br>"
 
       if e.is_a?(ArgumentError) && e.message =~ /invalid byte sequence in UTF-8/
-        msg += "A string was encountered that is not valid in UTF-8.\n" \
-               "The system encoding is #{Encoding.locale_charmap.inspect}.\n" \
-               "Refer to https://www.suse.com/support/kb/doc?id=7018056.\n\n"
+        msg += "A string was encountered that is not valid in UTF-8.<br>" \
+               "The system encoding is #{Encoding.locale_charmap.inspect}.<br>" \
+               "Refer to https://www.suse.com/support/kb/doc?id=7018056.<br><br>"
       end
 
-      msg + "Details: #{e.message}\n" \
-            "Caller:  #{e.backtrace.first}"
+      msg + "Caller:  #{escapeHTML(e.backtrace.first)}<br><br>" \
+            "Details: #{escapeHTML(e.message)}"
     end
 
     # Handles a SignalExpection
     private_class_method def self.handle_signal_exception(e)
       signame = Signal.signame(e.signo)
-      msg = "YaST received a signal %s and will exit.\n" % signame
+      msg = "YaST received a signal %s and will exit.<br>" % signame
       # sigterm are often sent by user
       if e.signo == 15
-        msg += "If termination is not sent by user then please report a bug report with logs.\n"
+        msg += "If termination is not sent by user then please report a bug report with logs.<br>"
       else
-        msg += "Please report a bug report with logs.\n"
+        msg += "Please report a bug report with logs.<br>"
       end
       msg += "Run save_y2logs to get complete logs."
 
@@ -252,18 +273,32 @@ module Yast
     private_class_method def self.handle_exception(e, client)
       Builtins.y2error("Client call failed with '%1' (%2) and backtrace %3",
         e.message,
-        e.class,
-        e.backtrace)
+        e.class.to_s,
+        e.backtrace.join("\n"))
 
-      msg = internal_error_msg(e)
+      if e.class.to_s == "CFA::AugeasParsingError"
+        msg = parsing_error_msg(e)
+      else
+        msg = internal_error_msg(e)
+      end
+      msg.gsub!(/\n/, "<br />")
+
+      # Pure approximation here
+      # 50 is for usable text area width, +6 is for additional lines like
+      # button line, Error caption and so. Whole dialog is at most 20 lines
+      # high to fit into screen
+      height = [msg.size / 50 + 6, 20].min
 
       if ask_to_run_debugger?
         Yast.import "Popup"
         Yast.import "Label"
-        msg += "\n\nStart the Ruby debugger now and debug the issue?" \
+        msg += "<br><br>Start the Ruby debugger now and debug the issue?" \
           " (Experts only!)"
 
-        if Popup.YesNoHeadline(Label.ErrorMsg, msg)
+        if Popup.AnyQuestionRichText(Label.ErrorMsg, msg, 60, height,
+          Label.YesButton,
+          Label.NoButton,
+          :focus_none)
           Debugger.start
           # Now you can restart the client and watch it step-by-step with
           # "next"/"step" commands or you can add some breakpoints into
@@ -272,7 +307,7 @@ module Yast
         end
       else
         Yast.import "Report"
-        Report.Error(msg)
+        Report.LongError(msg, height: height)
       end
     rescue Exception => e
       Builtins.y2internal("Error reporting failed with '%1' and backtrace %2",


### PR DESCRIPTION
https://trello.com/c/NaUW5kuD/2142-3-sles12-sp4-p3-1127906-augeas-exception-raised-to-the-user-when-a-malformed-grubcmdlinelinuxdefault-is-found
A backport from SLES15-SP2:
https://github.com/yast/yast-ruby-bindings/pull/253

![Bildschirmfoto_2020-10-30_15-58-47](https://user-images.githubusercontent.com/909986/97722542-0c2ea980-1acb-11eb-8b6d-f880ea7c58b9.png)
