### PR TITLE
Fix Jenkins build "Error opening terminal: unknown"

### DIFF
--- a/tests/builtins_regexps_spec.rb
+++ b/tests/builtins_regexps_spec.rb
@@ -83,13 +83,13 @@ describe "Yast::Builtins regular expresion methods" do
 
   describe ".regexptokenize" do
     it "works as expected" do
-      expect(Yast::Builtins.regexptokenize("aaabbBb", "(.*[A-Z]).*")).to eq(["aaabbB"])
+      expect(Yast::Builtins.regexptokenize("aaabb7b", "(.*[0-9]).*")).to eq(["aaabb7"])
       expect(Yast::Builtins.regexptokenize("aaabbb", "(.*ab)(.*)")).to eq(["aaab", "bb"])
       expect(Yast::Builtins.regexptokenize("aaabbb", "(.*ba).*")).to eq([])
       expect(Yast::Builtins.regexptokenize("aaabbb", "(.*ba).*(")).to eq(nil)
 
       # the result must be UTF-8 string
-      expect(Yast::Builtins.regexptokenize("aaabbBb", "(.*[A-Z]).*").first.encoding).to eq(Encoding::UTF_8)
+      expect(Yast::Builtins.regexptokenize("aaabb7b", "(.*[0-9]).*").first.encoding).to eq(Encoding::UTF_8)
     end
   end
 end

--- a/tests/integration/run.rb
+++ b/tests/integration/run.rb
@@ -29,7 +29,9 @@ end
 test = File.dirname(__FILE__) + "/std_streams_spec.rb"
 cmd = "rspec #{test} >#{OUTPUT} 2>&1"
 
-`tmux -c '#{cmd}; echo \$? > #{RESULT}'`
+tmux_out = `tmux -c '#{cmd}; echo \$? > #{RESULT}'`
+puts "Tmux output:"
+puts tmux_out
 if File.exist?(RESULT) && File.read(RESULT) == "0\n"
   puts "Test succeeded."
   cleanup

--- a/tests/integration/run.rb
+++ b/tests/integration/run.rb
@@ -29,8 +29,8 @@ end
 test = File.dirname(__FILE__) + "/std_streams_spec.rb"
 cmd = "rspec #{test} >#{OUTPUT} 2>&1"
 
-tmux_out = `tmux -c '#{cmd}; echo \$? > #{RESULT}'`
-puts "Tmux output:"
+tmux_out = `TERM=screen tmux -c '#{cmd}; echo \$? > #{RESULT}'`
+puts "Outside tmux output:"
 puts tmux_out
 if File.exist?(RESULT) && File.read(RESULT) == "0\n"
   puts "Test succeeded."

--- a/tests/integration/std_streams_spec.rb
+++ b/tests/integration/std_streams_spec.rb
@@ -3,12 +3,14 @@
 require_relative "../test_helper"
 require "yast/ui_shortcuts"
 
-Yast.import "UI"
-
 def std_puts(message)
   $stdout.puts "stdout: #{message}"
   $stderr.puts "stderr: #{message}"
 end
+
+std_puts "tty before importing UI"
+std_puts "TERM=#{ENV['TERM']}"
+Yast.import "UI"
 
 # Regression test for the fix of bnc#943757 implemented
 # in libyui-ncurses 2.47.3


### PR DESCRIPTION
Failing build: (likewise on ci.o.o and ci.s.d)
- https://ci.suse.de/view/YaST/job/yast-yast-ruby-bindings-master/26/console

Fixed build:
- https://ci.opensuse.org/view/Yast/job/yast-yast-ruby-bindings-mvidner/4/console

BTW I made a testing Jenkins job to debug and fix this: New project by copying the *yast-yast-ruby-bindings-master* project, then:
1. change the branch from `master` to `mvidner-test`
2. change the rake target from `osc:sr` to `osc:build` :exclamation: 