### PR TITLE
Test: menu items remain disabled after hotkeys are recomputed

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue Nov  3 17:39:19 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Test: menu items remain disabled after hotkeys are recomputed
+  (bsc#1178394)
+- 4.3.8
+
+-------------------------------------------------------------------
 Thu Oct 29 17:26:31 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added unit tests for NCMultiSelectionBox (bsc#1177985)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -40,9 +40,9 @@ Requires:       rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
 BuildRequires:  ruby-devel
 Requires:       yast2-core >= 3.2.2
 BuildRequires:  yast2-core-devel >= 3.2.2
-# MultiSelectionBox-test.rb
-Requires:       yast2-ycp-ui-bindings       >= 4.3.5
-BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.5
+# MenuBar-shortcuts-test.rb
+Requires:       yast2-ycp-ui-bindings       >= 4.3.6
+BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.6
 # The test suite includes a regression test (std_streams_spec.rb) for a
 # libyui-ncurses bug fixed in 2.47.3
 BuildRequires:  libyui-ncurses >= 2.47.3

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.7
+Version:        4.3.8
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/tests/libyui/menu_item_spec.rb
+++ b/tests/libyui/menu_item_spec.rb
@@ -27,4 +27,33 @@ describe "Menu Item" do
 
     @tui.send_keys "M-Q"        # &Quit
   end
+
+  bug = "1178394" # https://bugzilla.suse.com/show_bug.cgi?id=1178394
+  it "remains disabled after hotkeys are recomputed" do
+    @base = "menu_disabled_#{bug}"
+    @tui.await(/File.*Edit.*View/)
+    @tui.capture_pane_to("#{@base}-1-initial")
+
+    @tui.send_keys "M-E"        # &Edit
+    @tui.capture_pane_to("#{@base}-2-edit-menu-activated")
+
+    # select the 1st available item; it is Copy because Cut is disabled
+    @tui.send_keys "Enter"
+    @tui.capture_pane_to("#{@base}-3-copy-item-activated")
+    expect(@tui.capture_pane).to include("Last Event:", "copy")
+
+    # This changes the shortcuts!
+    @tui.send_keys "M-B"        # Extra &Buttons
+    @tui.capture_pane_to("#{@base}-4-extra-buttons-activated")
+
+    @tui.send_keys "M-T"        # Edi&t
+    @tui.capture_pane_to("#{@base}-5-edit-menu-activated")
+
+    # select the 1st available item; it is Copy because Cut is disabled
+    @tui.send_keys "Enter"
+    @tui.capture_pane_to("#{@base}-6-copy-item-activated")
+    expect(@tui.capture_pane).to include("Last Event:", "copy")
+
+    @tui.send_keys "M-Q"        # &Quit
+  end
 end

--- a/tests/libyui/menu_item_spec.rb
+++ b/tests/libyui/menu_item_spec.rb
@@ -1,16 +1,16 @@
 require_relative "rspec_tmux_tui"
 
 describe "Menu Item" do
-  bug = "1177760" # https://bugzilla.suse.com/show_bug.cgi?id=1177760
   around(:each) do |ex|
-    @base = "menu_hotkeys_#{bug}"
     @tui = YastTui.new
-    @tui.example("MenuBar1") do
+    @tui.example("MenuBar-shortcuts-test") do
       ex.run
     end
   end
 
+  bug = "1177760" # https://bugzilla.suse.com/show_bug.cgi?id=1177760
   it "has hotkeys in menu items, boo##{bug}" do
+    @base = "menu_hotkeys_#{bug}"
     @tui.await(/File.*Edit.*View/)
     @tui.capture_pane_to("#{@base}-1-initial")
 

--- a/tests/libyui/table_sort_spec.rb
+++ b/tests/libyui/table_sort_spec.rb
@@ -3,10 +3,10 @@ require_relative "rspec_tmux_tui"
 describe "Table" do
   context "when it sorts the items," do
     around(:each) do |ex|
-      yast_ncurses = "#{__dir__}/yast_ncurses"
+      y2start = "ruby -r #{__dir__}/../test_helper #{__dir__}/../../src/y2start/y2start"
       @base = "table_sort"
       @tui = TmuxTui.new
-      @tui.new_session "#{yast_ncurses} #{__dir__}/#{@base}.rb change-current-item" do
+      @tui.new_session "#{y2start} #{__dir__}/#{@base}.rb -a change-current-item ncurses" do
         ex.run
       end
     end
@@ -30,8 +30,6 @@ describe "Table" do
 
     bug = "1177145" # https://bugzilla.suse.com/show_bug.cgi?id=1177145
     it "ChangeWidget(_, :CurrentItem) activates the correct line, boo##{bug}" do
-      pending "not fixed yet"
-
       base = @base + "_current_item"
       @tui.await(/Table sorting test/)
       @tui.capture_pane_to("#{base}-1-ccc-selected")


### PR DESCRIPTION
- bug https://bugzilla.opensuse.org/show_bug.cgi?id=1178394
- the fix is https://github.com/libyui/libyui-qt/pull/139
- half of test case https://github.com/yast/yast-ycp-ui-bindings/pull/60
- this is the other half

Well, sort of. The bug is in libyui-qt and we test libyui-ncurses. Defense in depth.

Includes enabling the test for https://bugzilla.suse.com/show_bug.cgi?id=1177145 which got fixed together with https://bugzilla.suse.com/show_bug.cgi?id=1176402.