### PR TITLE
Build fix for "error creating /run/tmux/399" (bsc#1178394)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Nov 12 10:20:58 UTC 2020 - Martin Vidner <mvidner@suse.com>
+
+- Build fix for "error creating /run/tmux/399" (bsc#1178394)
+- 4.3.9
+
+-------------------------------------------------------------------
 Tue Nov  3 17:39:19 UTC 2020 - Martin Vidner <mvidner@suse.com>
 
 - Test: menu items remain disabled after hotkeys are recomputed

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.8
+Version:        4.3.9
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -89,6 +89,9 @@ make install DESTDIR=$RPM_BUILD_ROOT
 cd -
 
 %check
+# Build workers are set up without systemd so the default /run/tmux dir
+# will not be present (unless clamav pulls systemd in, on SLE)
+export TMUX_TMPDIR=/tmp
 cd build
 make test ARGS=-V
 cd -


### PR DESCRIPTION
Build workers are set up without systemd so the default /run/tmux dir
will not be present (unless clamav pulls systemd in, on SLE)
So we explicitly set the temporary directory to /tmp.

Fixes this build failure: https://build.opensuse.org/package/live_build_log/openSUSE:Factory:Staging:D/yast2-ruby-bindings/standard/x86_64