### PR TITLE
Unit Test for Menu Bar Shortcuts Priority

### DIFF
--- a/tests/libyui/menu_item_spec.rb
+++ b/tests/libyui/menu_item_spec.rb
@@ -42,8 +42,7 @@ describe "Menu Item" do
     @tui.capture_pane_to("#{@base}-3-copy-item-activated")
     expect(@tui.capture_pane).to include("Last Event:", "copy")
 
-    # This changes the shortcuts!
-    @tui.send_keys "M-B"        # Extra &Buttons
+    @tui.send_keys "M-E"        # Extra &Buttons
     @tui.capture_pane_to("#{@base}-4-extra-buttons-activated")
 
     @tui.send_keys "M-T"        # Edi&t

--- a/tests/libyui/menu_item_spec.rb
+++ b/tests/libyui/menu_item_spec.rb
@@ -14,7 +14,7 @@ describe "Menu Item" do
     @tui.await(/File.*Edit.*View/)
     @tui.capture_pane_to("#{@base}-1-initial")
 
-    @tui.send_keys "M-V"        # &View
+    @tui.send_keys "M-V"        # &View menu
     @tui.capture_pane_to("#{@base}-2-view-menu-activated")
 
     @tui.send_keys "M-N"        # &Normal
@@ -34,7 +34,7 @@ describe "Menu Item" do
     @tui.await(/File.*Edit.*View/)
     @tui.capture_pane_to("#{@base}-1-initial")
 
-    @tui.send_keys "M-E"        # &Edit
+    @tui.send_keys "M-E"        # &Edit menu
     @tui.capture_pane_to("#{@base}-2-edit-menu-activated")
 
     # select the 1st available item; it is Copy because Cut is disabled
@@ -45,7 +45,11 @@ describe "Menu Item" do
     @tui.send_keys "M-E"        # Extra &Buttons
     @tui.capture_pane_to("#{@base}-4-extra-buttons-activated")
 
-    @tui.send_keys "M-T"        # Edi&t
+    # Enabling the extra buttons calls UI.ReplaceWidget() which triggers
+    # checking keyboard shortcuts which causes the menu tree to be rebuilt.
+    # The bug was that this did not honor the item enabled/disabled state.
+
+    @tui.send_keys "M-T"        # &Edit menu
     @tui.capture_pane_to("#{@base}-5-edit-menu-activated")
 
     # select the 1st available item; it is Copy because Cut is disabled

--- a/tests/libyui/menu_item_spec.rb
+++ b/tests/libyui/menu_item_spec.rb
@@ -1,17 +1,20 @@
 require_relative "rspec_tmux_tui"
 
 describe "Menu Item" do
-  around(:each) do |ex|
+  before(:all) do
+    @base = "multi_selection_box_basics"
     @tui = YastTui.new
-    @tui.example("MenuBar-shortcuts-test") do
-      ex.run
-    end
+    @tui.example("MenuBar-shortcuts-test")
+    @tui.await(/File.*Edit.*View/)
+  end
+
+  after(:all) do
+    @tui.send_keys "M-Q"        # &Quit
   end
 
   bug = "1177760" # https://bugzilla.suse.com/show_bug.cgi?id=1177760
-  it "has hotkeys in menu items, boo##{bug}" do
-    @base = "menu_hotkeys_#{bug}"
-    @tui.await(/File.*Edit.*View/)
+  it "has shortcuts in menu items, boo##{bug}" do
+    @base = "menu_shortcuts_#{bug}"
     @tui.capture_pane_to("#{@base}-1-initial")
 
     @tui.send_keys "M-V"        # &View menu
@@ -24,14 +27,47 @@ describe "Menu Item" do
     expect(@tui.capture_pane).to include("Last Event")
     # the output
     expect(@tui.capture_pane).to include("view_normal")
+  end
 
-    @tui.send_keys "M-Q"        # &Quit
+  bug = nil
+  it "menu shortcuts have higher priority than button shortcuts" do
+    @base = "menu_shortcuts_prio"
+    @tui.capture_pane_to("#{@base}-1-initial")
+
+    # No extra buttons: The "&View" menu has shortcut "V"
+    expect(@tui.capture_pane).not_to include("[File]", "[Edit]", "[View]")
+    @tui.send_keys "M-V"        # &View menu
+    @tui.capture_pane_to("#{@base}-2-view-menu-activated")
+    expect(@tui.capture_pane).to include("Normal", "Compact", "Detailed", "Zoom")
+    @tui.send_keys "Down"
+    @tui.send_keys "Enter"
+    @tui.capture_pane_to("#{@base}-3-view-compact-activated")
+    expect(@tui.capture_pane).to include("Last Event:", "view_compact")
+
+    # Toggle extra buttons
+    @tui.send_keys "M-B"        # Extra &Buttons
+    @tui.capture_pane_to("#{@base}-4-extra-buttons-activated")
+    expect(@tui.capture_pane).to include("[File]", "[Edit]", "[View]")
+
+    # With extra buttons: The "&View" menu still has shortcut "V"
+    @tui.send_keys "M-V"        # &View menu
+    @tui.capture_pane_to("#{@base}-5-view-menu-activated")
+    expect(@tui.capture_pane).to include("Normal", "Compact", "Detailed", "Zoom")
+    @tui.send_keys "Down"
+    @tui.send_keys "Down"
+    @tui.send_keys "Enter"
+    @tui.capture_pane_to("#{@base}-6-view-detailed-activated")
+    expect(@tui.capture_pane).to include("Last Event:", "view_detailed")
+
+    # And the "View" button has "W"
+    @tui.send_keys "M-W"        # Vie&w button
+    @tui.capture_pane_to("#{@base}-7-view-button-activated")
+    expect(@tui.capture_pane).to include("Last Event:", "b_view")
   end
 
   bug = "1178394" # https://bugzilla.suse.com/show_bug.cgi?id=1178394
-  it "remains disabled after hotkeys are recomputed" do
+  it "remains disabled after shortcuts are recomputed" do
     @base = "menu_disabled_#{bug}"
-    @tui.await(/File.*Edit.*View/)
     @tui.capture_pane_to("#{@base}-1-initial")
 
     @tui.send_keys "M-E"        # &Edit menu
@@ -42,21 +78,19 @@ describe "Menu Item" do
     @tui.capture_pane_to("#{@base}-3-copy-item-activated")
     expect(@tui.capture_pane).to include("Last Event:", "copy")
 
-    @tui.send_keys "M-E"        # Extra &Buttons
+    @tui.send_keys "M-B"        # Extra &Buttons
     @tui.capture_pane_to("#{@base}-4-extra-buttons-activated")
 
     # Enabling the extra buttons calls UI.ReplaceWidget() which triggers
     # checking keyboard shortcuts which causes the menu tree to be rebuilt.
     # The bug was that this did not honor the item enabled/disabled state.
 
-    @tui.send_keys "M-T"        # &Edit menu
+    @tui.send_keys "M-E"        # &Edit menu
     @tui.capture_pane_to("#{@base}-5-edit-menu-activated")
 
     # select the 1st available item; it is Copy because Cut is disabled
     @tui.send_keys "Enter"
     @tui.capture_pane_to("#{@base}-6-copy-item-activated")
     expect(@tui.capture_pane).to include("Last Event:", "copy")
-
-    @tui.send_keys "M-Q"        # &Quit
   end
 end


### PR DESCRIPTION
## Trello

https://trello.com/c/JfDqTpdi/2150-3-menu-bar-refinements

## Changes

- Start the test example only once for the duration of all 3 sub-tests

- Added a new test case for menu shortcuts priority: After the layout changes, the toplevel menus should still have their preferred keyboard shortcut, and any buttons that compete for the same ones are assigned different ones.

## Screenshots

![MenuBar-shortcuts-test-no-extra-buttons-ncurses](https://user-images.githubusercontent.com/11538225/99280251-6f416f80-2831-11eb-9c4c-a2af358ab54a.png)

![MenuBar-shortcuts-test-extra-buttons-ncurses](https://user-images.githubusercontent.com/11538225/99280277-74062380-2831-11eb-9be7-aefe32fd39b6.png)


## Travis Failures

Travis fails to build because the latest versions of libyui and yast-ycp-ui-bindings are not yet available in the Docker image used for building.


## Related PRs

- Master PR with the new feature: https://github.com/libyui/libyui/pull/175
- Extended the used UI example: https://github.com/yast/yast-ycp-ui-bindings/pull/61