### PR TITLE
Don't require libyui

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Nov 19 10:13:01 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Removed Requires / BuildRequires to libyui (build failure)
+  (related to bsc#1175489)
+- 4.3.11
+
+-------------------------------------------------------------------
 Mon Nov 16 16:21:33 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Added UI test for menu bar shortcut priority (bsc#1175489)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.10
+Version:        4.3.11
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -43,9 +43,6 @@ BuildRequires:  yast2-core-devel >= 3.2.2
 # MenuBar-shortcuts-test.rb
 Requires:       yast2-ycp-ui-bindings       >= 4.3.7
 BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.7
-# Higher priority for toplevel menu shortcuts
-Requires:	libyui >= 3.12.2
-BuildRequires:	libyui >= 3.12.2
 # The test suite includes a regression test (std_streams_spec.rb) for a
 # libyui-ncurses bug fixed in 2.47.3
 BuildRequires:  libyui-ncurses >= 2.47.3


### PR DESCRIPTION
Since libyui does not provide libyui, building with that requires fails.

libyui provides libyui14 etc. (including the SO number), but not the plain symbol libyui.
That means we'd have to adapt the SO number here as well whenever we need to break binary compatibility in our UI packages.

For now, we'll still let the UI test suite fail here if anything changes; that's better than adding another obscure source for build failures.

This supersedes https://github.com/libyui/libyui/pull/176 .

See also the IRC discussion there:

```
[10:59:26] <jreidinger> HuHa: it looks ok, just expect that it will fail when we bump so version due to "Multiple choices" for libyui ( e.g. libyui14 and libyui15 ) and we need to use Prefer in project config
[10:59:44] <HuHa> ok, so it's essentially useless (?)
[11:04:50] <jreidinger> HuHa: as said by Dimstar maybe better way is to simply require ( and maybe just BuildRequire as you do not need it during runtime ) that libyui-devel with proper version
[11:05:20] <HuHa> in that case I'd rather get rid of requiring any specific version for the UI tests completely
[11:05:24] <HuHa> and just let it fail
[11:05:34] <HuHa> because otherwise it will just fail in a completely obscure place
[11:06:09] <jreidinger> HuHa: it is fine for me. Especially as we have there version update of libyui-bindings which is also what usually happens
[11:06:20] <jreidinger> I mean ycp-ui-bindings
[11:06:38] <jreidinger> HuHa: so in general you can remove whole that new Build-Require lines of libyui
[11:06:58] <HuHa> yes
```