### PR TITLE
Handle installation console keyboard shortcut

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Feb 15 17:44:17 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Handle a special keyboard shortcut for starting the installation
+  console (jsc#PM-1895, jsc#SLE-16263)
+- 4.3.12
+
+-------------------------------------------------------------------
 Thu Nov 19 10:13:01 UTC 2020 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Removed Requires / BuildRequires to libyui (build failure)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.11
+Version:        4.3.12
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Builtin.cc
+++ b/src/binary/Builtin.cc
@@ -225,17 +225,14 @@ extern "C" {
     const char *entropy = NULL;
     const size_t entropy_len = 0;
 
-    char output[CRYPT_GENSALT_OUTPUT_SIZE];
-    char* retval = crypt_gensalt_rn (crypt_prefix, crypt_rounds, entropy,
-      entropy_len, output, sizeof(output));
+    char* retval = crypt_gensalt_ra (crypt_prefix, crypt_rounds, entropy, entropy_len);
 
     if (!retval)
     {
       y2error ("Unable to generate a salt, check your crypt settings.\n");
-      return 0;
     }
 
-    return strdup (retval);
+    return retval;
   }
 
 
@@ -273,7 +270,7 @@ extern "C" {
     }
     if (!salt)
     {
-      y2error ("Cannot create salt for sha512 crypt");
+      y2error ("Cannot create salt for crypt type %d", use_crypt);
       return 0;
     }
 

--- a/src/binary/Yast.cc
+++ b/src/binary/Yast.cc
@@ -243,6 +243,42 @@ static bool is_debug_event(YCPValue val)
 }
 
 /**
+ * Returns true if the input symbol starts special configuration.
+ * @param  val YCPSymbol returned from an UI input call
+ * @return true/false
+ */
+static bool is_config_symbol(YCPValue val)
+{
+    return !val.isNull() && val->isSymbol() &&
+        val->asSymbol()->symbol() == "special_key:config";
+}
+
+/**
+ * Returns true if the input is a config UI event.
+ * @param  val YCPMap returned from the UI::WaitForEvent call
+ * @return true/false
+ */
+static bool is_config_event(YCPValue val)
+{
+    // is it a map?
+    if (val.isNull() || !val->isMap())
+        return false;
+
+    YCPMap map = val->asMap();
+
+    YCPValue event_type = map->value(YCPString("EventType"));
+    // is map["EventType"] == "SpecialKeyEvent"?
+    if (event_type.isNull() || !event_type->isString() ||
+        event_type->asString()->value() != "SpecialKeyEvent")
+        return false;
+
+    YCPValue event_id = map->value(YCPString("ID"));
+    // is map["ID"] == :"special_key:config"?
+    return !event_id.isNull() && event_id->isSymbol() &&
+        event_id->asSymbol()->symbol() == "special_key:config";
+}
+
+/**
  * Start the Ruby debugger, it calls "Yast::Debugger.start" Ruby code.
  * See file ../ruby/yast/debugger.rb for more details.
  */
@@ -255,6 +291,38 @@ static void start_ruby_debugger()
     VALUE module = rb_const_get(rb_cObject, rb_intern("Yast"));
     VALUE klass = rb_const_get(module, rb_intern("Debugger"));
     rb_funcall(klass, rb_intern("start"), 0);
+}
+
+static VALUE require_console(...)
+{
+  rb_require("installation/console");
+  return Qtrue;
+}
+
+static VALUE rescue_require_console(...)
+{
+  y2warning("Loading the console failed!");
+  return Qfalse;
+}
+
+/**
+ * Start the configuration console, it calls "Installation::Console.run" Ruby code.
+ */
+static void start_config_console()
+{
+    y2milestone("Starting the configuration console...");
+
+    // catch the LoadError exception
+    VALUE success = rb_rescue2( &require_console, Qnil, &rescue_require_console,
+      Qnil, rb_eLoadError, 0);
+
+    // LoadError caught
+    if (success == Qfalse) return;
+
+    // call "Installation::Console.run"
+    VALUE installation = rb_const_get(rb_cObject, rb_intern("Installation"));
+    VALUE console = rb_const_get(installation, rb_intern("Console"));
+    rb_funcall(console, rb_intern("run"), 0);
 }
 
 /*
@@ -353,8 +421,9 @@ ycp_module_call_ycp_function(int argc, VALUE *argv, VALUE self)
       rb_funcall(argv[i->first], rb_intern("value="), 1, val);
     }
 
-    // hack: handle the Shift+Ctrl+Alt+D debugging magic key combination
-    // returned from UI calls, start the Ruby debugger when the magic key is received
+    // hack: handle the magic key combinations returned from UI calls,
+    // start the Ruby debugger or the installation console when the respective
+    // magic key is received
     if (strcmp(namespace_name, "UI") == 0)
     {
         if (
@@ -364,6 +433,18 @@ ycp_module_call_ycp_function(int argc, VALUE *argv, VALUE self)
         {
           y2milestone("UI::%s() caught magic debug key: %s", function_name, res->toString().c_str());
           start_ruby_debugger();
+        }
+        if (
+            (ui_input_function(function_name) && is_config_symbol(res)) ||
+            (ui_event_function(function_name) && is_config_event(res))
+        )
+        {
+          y2milestone("UI::%s() caught magic config key: %s", function_name, res->toString().c_str());
+          start_config_console();
+
+          // restart the UI call, handle the config event completely internally,
+          // return a real user input value
+          return ycp_module_call_ycp_function(argc, argv, self);
         }
     }
 


### PR DESCRIPTION
- Handle a special keyboard shortcut for starting the installation console ([jsc#PM-1895](https://jira.suse.com/browse/PM-1895), [jsc#SLE-16263](https://jira.suse.com/browse/SLE-16263))
- The implementation is similar to handling the debugging keyboard shortcut
- Related to libyui/libyui#179
- Also fixed build error in Leap 15.2/15.3:
  - `Builtin.cc:228:17: error: 'CRYPT_GENSALT_OUTPUT_SIZE' was not declared in this scope`
  - Fixed by using the `crypt_gensalt_ra()` function which does not need a static buffer, but it allocates the memory for the result itself (see [`man crypt_gensalt_ra`](https://man.cx/crypt_gensalt(3)))
  - Should be also faster as it avoids copying the content of the static buffer

### Testing

Tested manually with the `repositories` client (uses the `UI::WaitForEvent()` call) and the `host` client (uses the `UI::UserInput()` call). Works fine in both cases.
   