### PR TITLE
Change the special keybard shortcut

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Thu Mar  4 14:44:36 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Change the special keybard shortcut to start a graphical
+  menu instead of a low level command line console,
+- The command line console can be started from there as well
+- Related to jsc#PM-1895, jsc#SLE-16263
+- 4.3.13
+
+-------------------------------------------------------------------
 Mon Feb 15 17:44:17 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Handle a special keyboard shortcut for starting the installation

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.12
+Version:        4.3.13
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Yast.cc
+++ b/src/binary/Yast.cc
@@ -306,7 +306,7 @@ static VALUE rescue_require_console(...)
 }
 
 /**
- * Start the configuration console, it calls "Installation::Console.run" Ruby code.
+ * Start the configuration console, it calls "Installation::Console::Menu.run" Ruby code.
  */
 static void start_config_console()
 {

--- a/src/binary/Yast.cc
+++ b/src/binary/Yast.cc
@@ -295,7 +295,7 @@ static void start_ruby_debugger()
 
 static VALUE require_console(...)
 {
-  rb_require("installation/console");
+  rb_require("installation/console/menu");
   return Qtrue;
 }
 
@@ -319,10 +319,11 @@ static void start_config_console()
     // LoadError caught
     if (success == Qfalse) return;
 
-    // call "Installation::Console.run"
+    // call "Installation::Console::Menu.run"
     VALUE installation = rb_const_get(rb_cObject, rb_intern("Installation"));
     VALUE console = rb_const_get(installation, rb_intern("Console"));
-    rb_funcall(console, rb_intern("run"), 0);
+    VALUE menu = rb_const_get(console, rb_intern("Menu"));
+    rb_funcall(menu, rb_intern("run"), 0);
 }
 
 /*


### PR DESCRIPTION
- Start a graphical menu instead of a low level command line console
- The command line console can be started from there as well
- Related to https://github.com/yast/yast-installation/pull/905
- Related to [jsc#PM-1895](https://jira.suse.com/browse/PM-1895), [jsc#SLE-16263](https://jira.suse.com/browse/SLE-16263)
- Tested manually in installed system
- 4.3.13