### PR TITLE
Fixed password encrypting functions in SLE15-SP2/Leap 15.2 and older

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Mar 17 13:55:01 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
+
+- Fixed password encrypting functions to work correctly also
+  in older products (SLE15-SP2/Leap 15.2 and older)
+  (related to bsc#1176924)
+- 4.3.14
+
+-------------------------------------------------------------------
 Thu Mar  4 14:44:36 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Change the special keybard shortcut to start a graphical

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.13
+Version:        4.3.14
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/binary/Builtin.cc
+++ b/src/binary/Builtin.cc
@@ -225,7 +225,7 @@ extern "C" {
     char* retval = crypt_gensalt_ra (crypt_prefix, crypt_rounds, NULL, 0);
 
     // auto entropy might not be supported in some older systems (15.2 and older),
-    // if we get the "Invalid argument" error then read some entropy from
+    // if we get the EINVAL "Invalid argument" error then read some entropy from
     // /dev/urandom and try again
     if (!retval && errno == EINVAL)
     {
@@ -240,9 +240,11 @@ extern "C" {
 
       char entropy[16];
       const size_t entropy_len = sizeof(entropy);
-      if (read_loop (fd, entropy, entropy_len) != entropy_len)
+      int read_size = read_loop (fd, entropy, entropy_len);
+      close (fd);
+
+      if (read_size != entropy_len)
       {
-        close (fd);
         y2error ("Unable to obtain entropy from %s\n", device);
         return 0;
       }

--- a/src/binary/Builtin.cc
+++ b/src/binary/Builtin.cc
@@ -222,15 +222,36 @@ extern "C" {
   make_crypt_salt (const char* crypt_prefix, int crypt_rounds)
   {
     // use gensalt own auto entropy
-    const char *entropy = NULL;
-    const size_t entropy_len = 0;
+    char* retval = crypt_gensalt_ra (crypt_prefix, crypt_rounds, NULL, 0);
 
-    char* retval = crypt_gensalt_ra (crypt_prefix, crypt_rounds, entropy, entropy_len);
+    // auto entropy might not be supported in some older systems (15.2 and older),
+    // if we get the "Invalid argument" error then read some entropy from
+    // /dev/urandom and try again
+    if (!retval && errno == EINVAL)
+    {
+      const char* device = "/dev/urandom";
+
+      int fd = open (device, O_RDONLY);
+      if (fd < 0)
+      {
+        y2error ("Can't open %s for reading: %s\n", device, strerror (errno));
+        return 0;
+      }
+
+      char entropy[16];
+      const size_t entropy_len = sizeof(entropy);
+      if (read_loop (fd, entropy, entropy_len) != entropy_len)
+      {
+        close (fd);
+        y2error ("Unable to obtain entropy from %s\n", device);
+        return 0;
+      }
+
+      retval = crypt_gensalt_ra (crypt_prefix, crypt_rounds, entropy, entropy_len);
+    }
 
     if (!retval)
-    {
-      y2error ("Unable to generate a salt, check your crypt settings.\n");
-    }
+      y2error ("Unable to generate a salt, check your crypt settings: %s.\n", strerror(errno));
 
     return retval;
   }


### PR DESCRIPTION
### Problem 

The encrypting builtins return `nil` in SLE15-SP2/Leap 15.2 and older, the unit tests fail with
```
Failures:

   1) Yast::Builtins.crypt works as expected
      Failure/Error: expect(res).to be_a String
        expected nil to be a kind of String
```

- See https://build.suse.de/package/live_build_log/Devel:YaST:Head/yast2-ruby-bindings/SUSE_SLE-15-SP2_GA/aarch64
- Or https://build.opensuse.org/package/live_build_log/YaST:Head/yast2-ruby-bindings/openSUSE_Leap_15.2/x86_64
- It turned out that in the older distros the crypt function returns `EINVAL` error when the passed entropy is `NULL`. In that case we need to explicitly pass some entropy.
- Partially reverts #250
- Related to bsc#1176924
- Tested in Leap 15.1
