### PR TITLE
Adjust the rjust size to show the zVM family name correctly

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Apr 14 10:58:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
+
+- Made the architecture string to fit in a 80x24 terminal
+  (bsc#1184474).
+- 4.4.0
+
+-------------------------------------------------------------------
 Wed Mar 17 13:55:01 UTC 2021 - Ladislav Slezák <lslezak@suse.cz>
 
 - Fixed password encrypting functions to work correctly also

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.3.14
+Version:        4.4.0
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -95,7 +95,7 @@ module Yast
         architecture = ""
       end
       left_title = "YaST2 - #{client_name}#{hostname}"
-      left_title + architecture.rjust(80-left_title.size)
+      left_title + architecture.rjust(78-left_title.size)
     end
 
 


### PR DESCRIPTION
## Problem

When using **ncurses** with **80x24** the zVM family name is not shown correctly as we can see below.

![S390QethActivation](https://user-images.githubusercontent.com/7056681/114558669-d5a4af80-9c62-11eb-8da6-6ffd4550ed68.png)

Found when working in https://bugzilla.suse.com/show_bug.cgi?id=1184474

## Solution

Use **78** instead of **80** showing the zVM family name completely and also an extra space in **80x24**.

![S390QethMACConfirmation80x24](https://user-images.githubusercontent.com/7056681/114699554-5d98c100-9d18-11eb-8968-b666663d66c0.png)

Will fix only in master by now.
