### PR TITLE
avoid crash caused by missing client argument

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed Jun 16 14:43:23 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- When a WFM client returns a value not representable in YCP,
+  raise a meaningful exception instead of crashing on an undefined
+  variable (bsc#1187230)
+- 4.4.1
+
+-------------------------------------------------------------------
 Wed Apr 14 10:58:39 UTC 2021 - Knut Anderssen <kanderssen@suse.com>
 
 - Made the architecture string to fit in a 80x24 terminal

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.4.0
+Version:        4.4.1
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/wfm.rb
+++ b/src/ruby/yast/wfm.rb
@@ -326,14 +326,15 @@ module Yast
       log.info "To abort the process was requested from client #{client}: #{e.class}: #{e.message}"
     end
 
-    private_class_method def self.check_client_result_type!(result)
+    # @param client [String]
+    private_class_method def self.check_client_result_type!(result, client)
       allowed_types = Ops::TYPES_MAP.values.flatten
       allowed_types.delete(::Object) # remove generic type for any
 
       # check if response is allowed
       allowed = allowed_types.any? { |t| result.is_a? t }
 
-      raise "Invalid type #{result.class} from client #{client}" unless allowed
+      raise "Non-YCP type #{result.class} returned from client #{client}" unless allowed
     end
 
     # @private wrapper to run client in ruby
@@ -344,7 +345,7 @@ module Yast
         Debugger.start_from_env
         Profiler.start_from_env
         result = eval(code, GLOBAL_WFM_CONTEXT.binding, client)
-        check_client_result_type!(result)
+        check_client_result_type!(result, client)
 
         return result
       # SystemExit < Exception, raised by Kernel#exit

--- a/tests/test_module/clients/wrong_result.rb
+++ b/tests/test_module/clients/wrong_result.rb
@@ -1,0 +1,10 @@
+module Yast
+  class WrongResultClient
+    def main
+      Regexp.new(".*")
+    end
+  end
+end
+
+Yast::WrongResultClient.new.main
+

--- a/tests/wfm_spec.rb
+++ b/tests/wfm_spec.rb
@@ -4,6 +4,22 @@ require_relative "test_helper"
 
 require "yast"
 
+# due to dependencies lets create here fake Report and Mode classes
+# because ruby bindings does not depend on yast2 but uses some of its functionality
+module Yast
+  class Report
+    def self.LongError(msg, height: 0)
+      msg
+    end
+  end
+
+  class Mode
+    def self.auto
+      true # fake true to avoid debugger
+    end
+  end
+end
+
 module Yast
   describe WFM do
     describe ".CallFunction" do
@@ -27,6 +43,12 @@ module Yast
         EOS
         stdout_stderr = `ruby -e "#{script}" 2>&1`
         expect(stdout_stderr).to eq ""
+      end
+
+      it "returns false and reports error if result is not ycp type" do
+        expect(Yast::Report).to receive(:LongError)
+          .with(/Non-YCP type Regexp returned from client .*wrong_result\.rb/, anything)
+        expect(WFM.CallFunction("wrong_result")).to eq false
       end
 
       it "raises error if first parameter is not string" do


### PR DESCRIPTION
bsc: https://bugzilla.suse.com/show_bug.cgi?id=1187230

Found during manual testing. Not sure about the best solution as result is still exception and internal error ( and it is really our internal fault, but maybe we can present it nicer? )