### PR TITLE
Avoid IO exception

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jul 21 14:30:46 UTC 2021 - José Iván López González <jlopez@suse.com>
+
+- Avoid IO exception when the stderr was closed. This could happen
+  when the parent process was killed, see bsc#1154854.
+- 4.4.2
+
+-------------------------------------------------------------------
 Wed Jun 16 14:43:23 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - When a WFM client returns a value not representable in YCP,

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.4.1
+Version:        4.4.2
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -137,7 +137,13 @@ module Yast
     private_class_method def self.signal_handler(name)
       Signal.trap(name, "IGNORE")
 
-      $stderr.puts "YaST got signal #{name}."
+      # Exception swallowing: writing to stderr could fail if the parent process was killed,
+      # see bsc#1154854.
+      begin
+        $stderr.puts "YaST got signal #{name}."
+      rescue Errno::EIO
+        # Nothing to do
+      end
 
       signal_log_open do |f|
         f.puts "=== #{Time.now} ==="

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -138,7 +138,7 @@ module Yast
       Signal.trap(name, "IGNORE")
 
       # Exception swallowing: writing to stderr could fail if the parent process was killed,
-      # see bsc#1154854.
+      # see bsc#1154854. Note that $stderr.closed? returns false.
       begin
         $stderr.puts "YaST got signal #{name}."
       rescue Errno::EIO


### PR DESCRIPTION
## Problem

When a signal is sent to YaST (e.g., when the parent terminal is killed), YaST tries writing a message to the standard error output. But stderr can be closed at that time, making YaST to raise an exception.

* https://bugzilla.suse.com/show_bug.cgi?id=1154854


## Solution

Avoid IO error by doing "exception swallowing"  for *Errno::EIO* while writing to stderr.

See also https://github.com/yast/yast-control-center/pull/51.

## Testing

Manually tested.