### PR TITLE
Ruby3

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Mon Nov 29 15:34:14 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
+
+- Avoid warning in ruby3.0 ( lets just reuse bug for older change
+  of ruby version bsc#1044312 )
+- 4.4.5
+
+-------------------------------------------------------------------
 Wed Aug 18 14:32:24 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Fix dependency on s390 (revealed by previous fix for bsc#972548)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.4.4
+Version:        4.4.5
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/ui.rb
+++ b/src/ruby/yast/ui.rb
@@ -1,5 +1,5 @@
-module Yast
-  # This is a counterpart to init_ui in the C code.
-  # It really belongs near it but I don't know how to code a proc in C.
-  ObjectSpace.define_finalizer(Yast, proc { Yast.ui_finalizer })
-end
+# This is a counterpart to init_ui in the C code.
+# It really belongs near it but I don't know how to code a proc in C.
+# Workaround warning in ruby3. See e.g. https://github.com/appsignal/rdkafka-ruby/pull/160/files#r656637223
+mod = Yast
+ObjectSpace.define_finalizer(mod, proc { mod.ui_finalizer })


### PR DESCRIPTION
Issue: ruby 3.0 produce warning:
```
/home/abuild/rpmbuild/BUILD/yast2-ruby-bindings-4.4.4/src/ruby/yast/ui.rb:4: warning: finalizer references object to be finalized
```

Fix:
store reference early, so it does not warn when it is finalized