### PR TITLE
Added yast/rspec/helpers.rb (related to bsc#1194784)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Jan 17 14:03:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added yast/rspec/helpers.rb (related to bsc#1194784)
+- 4.4.7
+
+-------------------------------------------------------------------
 Mon Nov 29 20:21:23 UTC 2021 - Josef Reidinger <jreidinger@suse.com>
 
 - Avoid timing issue in integration tests ( bsc#1193192 )

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.4.6
+Version:        4.4.7
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/rspec.rb
+++ b/src/ruby/yast/rspec.rb
@@ -1,6 +1,7 @@
+require "yast/rspec/helpers"
+require "yast/rspec/matchers"
 require "yast/rspec/scr"
 require "yast/rspec/shortcuts"
-require "yast/rspec/matchers"
 
 RSpec.configure do |c|
   c.include Yast::RSpec::Shortcuts

--- a/src/ruby/yast/rspec/helpers.rb
+++ b/src/ruby/yast/rspec/helpers.rb
@@ -43,7 +43,9 @@ module Yast
       #   verifying doubles!
       # @param block [Block] optional method definitions, they should provide
       #   the same API as the original module, this can be combined with the
-      #   "methods" parameter
+      #   `methods` parameter. The block is evaluated in the context of the
+      #   defined modules so you can also use the helpers like `attr_reader`
+      #   or define constants.
       def self.define_yast_module(name, methods: [:fake_method], force: false, &block)
         # sanity check, make sure the code coverage is already running if it is enabled
         if ENV["COVERAGE"] && (!defined?(SimpleCov) || !SimpleCov.running)

--- a/src/ruby/yast/rspec/helpers.rb
+++ b/src/ruby/yast/rspec/helpers.rb
@@ -20,21 +20,22 @@ module Yast
       #   present in the system, this might be useful to actually test the stubs.
       #   Just define the YAST_FORCE_MODULE_STUBS environment variable.
       #
-      # @example Mock empty `AutoInstall` module
-      # Yast::RSpec::Helpers.define_yast_module("AutoInstall")
+      # @example Mock empty `Language` module
+      # Yast::RSpec::Helpers.define_yast_module("Language")
       #
       # @example Mock the `Language` module with the `language` method
       # Yast::RSpec::Helpers.define_yast_module("Language", methods: [:language])
       #
-      # @example Mock the `AutoinstStorage` module with `Import` taking one parameter
-      # Yast::RSpec::Helpers.define_yast_module("AutoinstStorage") do
-      #   def Import(_config); end
+      # @example Mock the `Language` module with `language` returning a default value
+      # Yast::RSpec::Helpers.define_yast_module("Language") do
+      #   def language
+      #     "en_US"
+      #   end
       # end
       #
       # @param name [String] name of the YaST module
       # @param methods [Array<Symbol>] optional list of defined methods,
-      #   the defined methods accept no parameter, if you need a parameter
-      #   then define it in the block
+      #   the defined methods accept any parameters
       # @param force [Boolean] force creating the fake implementation even when
       #   the module is present in the system, can be also set by the
       #   YAST_FORCE_MODULE_STUBS environment variable. This might be useful
@@ -77,7 +78,8 @@ module Yast
 
         # create a fake implementation of the module
         new_class = Class.new do
-          methods.each { |m| define_singleton_method(m) {} }
+          # the defined method takes any number of parameters, a block is allowed as well
+          methods.each { |m| define_singleton_method(m) {|*_a, **_k, &_b|} }
           instance_eval(&block) if block_given?
         end
 

--- a/src/ruby/yast/rspec/helpers.rb
+++ b/src/ruby/yast/rspec/helpers.rb
@@ -18,7 +18,7 @@ module Yast
       #
       # @note You can force using the defined stubs although the modules are
       #   present in the system, this might be useful to actually test the stubs.
-      #   Just the define the YAST_FORCE_MODULE_STUBS environment variable.
+      #   Just define the YAST_FORCE_MODULE_STUBS environment variable.
       #
       # @example Mock empty `AutoInstall` module
       # Yast::RSpec::Helpers.define_yast_module("AutoInstall")
@@ -42,7 +42,8 @@ module Yast
       #   of mocking. But use it carefully, this defeats the purpose of the RSpec
       #   verifying doubles!
       # @param block [Block] optional method definitions, they should provide
-      #   the same API as the original module
+      #   the same API as the original module, this can be combined with the
+      #   "methods" parameter
       def self.define_yast_module(name, methods: [:fake_method], force: false, &block)
         # sanity check, make sure the code coverage is already running if it is enabled
         if ENV["COVERAGE"] && (!defined?(SimpleCov) || !SimpleCov.running)

--- a/src/ruby/yast/rspec/helpers.rb
+++ b/src/ruby/yast/rspec/helpers.rb
@@ -1,0 +1,58 @@
+require "yast"
+
+module Yast
+  module RSpec
+    module Helpers
+      # Helper for defining YaST modules which might not be present in
+      # the system when running the tests.
+      #
+      # When the requested module is present in the system then it is imported
+      # as usually. If it is missing a substitute definition is created.
+      #
+      # @note This needs to be called *after* starting code coverage with
+      # `SimpleCov.start` so the coverage of the imported modules is correctly
+      # counted.
+      #
+      # @example Mock the `Language` module and the `Language.language` method
+      # Yast::RSpec::Helpers.define_yast_module("Language") do
+      #   # see modules/Language.rb in yast2-country
+      #   module Yast
+      #     class LanguageClass < Module
+      #       # @return [String]
+      #       def language; end
+      #     end
+      #     Language = LanguageClass.new
+      #   end
+      # end
+      #
+      # @example Mock empty `AutoInstall` module
+      # Yast::RSpec::Helpers.define_yast_module("AutoInstall")
+      #
+      # @param name [String] name of the YaST module
+      # @param block [Block] optional module definition, it should provide
+      #   the same API as the original module, it is enough to define only the
+      #   methods used in the tests, if no block is passed an empty module is defined
+      def self.define_yast_module(name, &block)
+        # sanity check, make sure the code coverage is already running if it is enabled
+        if ENV["COVERAGE"] && (!defined?(SimpleCov) || !SimpleCov.running)
+          abort "\nERROR: The `define_yast_module` method needs to be called *after* " \
+            "enabling the code coverage tracking with `SimpleCov.start`!\n" \
+            "  Called from: #{caller(1).first}\n\n"
+        end
+
+        # try loading the module, it might be present in the system (running locally
+        # or in GitHub Actions), mock it only when missing (e.g. in OBS build)
+        Yast.import(name)
+        puts "Found module Yast::#{name}"
+      rescue NameError
+        warn "Module Yast::#{name} not found"
+        if block_given?
+          block.call
+        else
+          # create a fake implementation of the module
+          Yast.const_set(name.to_sym, Class.new { def self.fake_method; end })
+        end
+      end
+    end
+  end
+end

--- a/tests/rspec_helpers_spec.rb
+++ b/tests/rspec_helpers_spec.rb
@@ -1,0 +1,35 @@
+#!/usr/bin/env rspec
+
+require_relative "test_helper"
+
+require "yast/rspec/helpers"
+
+describe Yast::RSpec::Helpers do
+  describe ".define_yast_module" do
+    context "the requested module is present" do
+      it "imports the module" do
+        # load the tests/test_module/modules/ExampleTestModule.ycp module
+        Yast::RSpec::Helpers.define_yast_module("ExampleTestModule")
+        expect(defined?(Yast::ExampleTestModule)).to eq("constant")
+      end
+
+      it "does not evaluate the passed block" do
+        # load the tests/test_module/modules/ExampleTestModule.ycp module
+        expect { |b| Yast::RSpec::Helpers.define_yast_module("ExampleTestModule", &b) }.to_not \
+          yield_control
+      end
+    end
+
+    context "the module is missing" do
+      it "evaluates the passed block" do
+        expect { |b| Yast::RSpec::Helpers.define_yast_module("NotExistingModule", &b) }.to \
+          yield_control
+      end
+
+      it "defines an empty fake module when a block is not passed" do
+        expect { Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule") }.to \
+          change { defined?(Yast::VerySpecialNotExistingModule) }.from(nil).to("constant")
+      end
+    end
+  end
+end

--- a/tests/rspec_helpers_spec.rb
+++ b/tests/rspec_helpers_spec.rb
@@ -7,10 +7,21 @@ require "yast/rspec/helpers"
 describe Yast::RSpec::Helpers do
   describe ".define_yast_module" do
     context "the requested module is present" do
+      after do
+        # unload the testing YaST module
+        Yast.send(:remove_const, :ExampleTestModule) if defined?(Yast::ExampleTestModule)
+      end
+
       it "imports the module" do
+        # make sure the module was not accidentally loaded before
+        Yast.send(:remove_const, :ExampleTestModule) if defined?(Yast::ExampleTestModule)
+
         # load the tests/test_module/modules/ExampleTestModule.ycp module
-        Yast::RSpec::Helpers.define_yast_module("ExampleTestModule")
-        expect(defined?(Yast::ExampleTestModule)).to eq("constant")
+        expect { Yast::RSpec::Helpers.define_yast_module("ExampleTestModule") }.to \
+          change { defined?(Yast::ExampleTestModule) }.from(nil).to("constant")
+
+        # check that the testing module is really loaded
+        expect(Yast::ExampleTestModule.respond_to?(:arch_short)).to be true
       end
 
       it "does not evaluate the passed block" do
@@ -18,17 +29,45 @@ describe Yast::RSpec::Helpers do
         expect { |b| Yast::RSpec::Helpers.define_yast_module("ExampleTestModule", &b) }.to_not \
           yield_control
       end
+
+      it "creates the fake implementation when forced" do
+        Yast::RSpec::Helpers.define_yast_module("ExampleTestModule", methods: [:foo], force: true)
+        expect(Yast::ExampleTestModule.respond_to?(:foo)).to be true
+      end
     end
 
     context "the module is missing" do
+      after do
+        # cleanup the defined testing YaST module
+        Yast.send(:remove_const, :VerySpecialNotExistingModule) if defined?(Yast::VerySpecialNotExistingModule)
+      end
+
+      it "defines an empty fake module" do
+        expect { Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule") }.to \
+          change { defined?(Yast::VerySpecialNotExistingModule) }.from(nil).to("constant")
+      end
+
       it "evaluates the passed block" do
-        expect { |b| Yast::RSpec::Helpers.define_yast_module("NotExistingModule", &b) }.to \
+        expect { |b| Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule", &b) }.to \
           yield_control
       end
 
-      it "defines an empty fake module when a block is not passed" do
-        expect { Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule") }.to \
-          change { defined?(Yast::VerySpecialNotExistingModule) }.from(nil).to("constant")
+      it "defines the requested module methods" do
+        Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule", methods: [:foo])
+
+        expect(Yast::VerySpecialNotExistingModule.respond_to?(:foo)).to be true
+        # by default no parameter accepted
+        expect(Yast::VerySpecialNotExistingModule.method(:foo).arity).to eq(0)
+      end
+
+      it "defines the methods passed in the block" do
+        Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule") do
+          def foo(_bar, _baz); end
+        end
+
+        expect(Yast::VerySpecialNotExistingModule.respond_to?(:foo)).to be true
+        # accepts two parameters
+        expect(Yast::VerySpecialNotExistingModule.method(:foo).arity).to eq(2)
       end
     end
   end

--- a/tests/rspec_helpers_spec.rb
+++ b/tests/rspec_helpers_spec.rb
@@ -56,8 +56,8 @@ describe Yast::RSpec::Helpers do
         Yast::RSpec::Helpers.define_yast_module("VerySpecialNotExistingModule", methods: [:foo])
 
         expect(Yast::VerySpecialNotExistingModule.respond_to?(:foo)).to be true
-        # by default no parameter accepted
-        expect(Yast::VerySpecialNotExistingModule.method(:foo).arity).to eq(0)
+        # by default accepts any parameters
+        expect(Yast::VerySpecialNotExistingModule.method(:foo).arity).to eq(-1)
       end
 
       it "defines the methods passed in the block" do


### PR DESCRIPTION
- See https://github.com/yast/yast-packager/pull/599#pullrequestreview-853381879
- Let's share the helper method
- It can also replace the existing stubs like
```ruby
def stub_module(name)
  Yast.const_set(name.to_sym, Class.new { def self.fake_method; end })
end

stub_module("Proxy")
```
with 
```ruby
Yast::RSpec::Helpers.define_yast_module("Proxy")
```