### PR TITLE
Set "x509ignoreCN=0" GODEBUG environment variable (bsc#1195220)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,16 @@
 -------------------------------------------------------------------
+Mon Feb  7 13:25:10 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Set "x509ignoreCN=0" GODEBUG environment variable option to
+  enable CN (Common Name) matching in SSL certificates in Go programs
+  (e.g. suseconnect-ng). Without it the CN would be ignored and
+  only the SAN (Subject Alternative Name) certificate fields would
+  be used. But the self-signed certificates usually only contain
+  the CN field without SAN so YaST could not connect to SMT/RMT
+  registration servers. (bsc#1195220)
+- 4.4.8
+
+-------------------------------------------------------------------
 Mon Jan 17 14:03:14 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added yast/rspec/helpers.rb (related to bsc#1194784)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.4.7
+Version:        4.4.8
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -2,15 +2,30 @@ module Yast
   module Y2StartHelpers
     # Configure global environment for YaST
     #
-    # Currently it only sets values for $PATH.
+    # Currently it only sets values for $PATH and $GODEBUG.
     #
     # By configuring $PATH, it ensures that correct external programs are executed when
     # relative paths are given, so possible CVEs are avoided when running YaST.
+    #
+    # $GODEBUG is configured to enable CN (Common Name) matching in SSL certificates
+    # used by Go programs (suseconnect-ng used by registration)
     #
     # Note that forked processes will inherit the environment configuration, for example
     # when executing commands via SCR or Cheetah.
     def self.config_env
       ENV["PATH"] = "/sbin:/usr/sbin:/usr/bin:/bin"
+
+      # Note: this setting was removed in go-1.17 (https://go.dev/doc/go1.17),
+      # SLE15 uses go-1.16
+      if ENV["GODEBUG"]
+        # check if already enabled
+        if !ENV["GODEBUG"].include?("x509ignoreCN=0")
+          # append to existing settings
+          ENV["GODEBUG"] = "#{ENV["GODEBUG"]},x509ignoreCN=0"
+        end
+      else
+        ENV["GODEBUG"] = "x509ignoreCN=0"
+      end
     end
 
     # Parses ARGV of y2start. it returns map with keys:

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -8,7 +8,8 @@ module Yast
     # relative paths are given, so possible CVEs are avoided when running YaST.
     #
     # $GODEBUG is configured to enable CN (Common Name) matching in SSL certificates
-    # used by Go programs (suseconnect-ng used by registration)
+    # used by Go programs (suseconnect-ng used by registration).
+    # See https://bugzilla.suse.com/show_bug.cgi?id=1195220
     #
     # Note that forked processes will inherit the environment configuration, for example
     # when executing commands via SCR or Cheetah.


### PR DESCRIPTION
- https://bugzilla.suse.com/show_bug.cgi?id=1195220
- Enable CN (Common Name) matching in SSL certificates in Go programs (e.g. `suseconnect-ng`). Without it the CN would be ignored and only the SAN (Subject Alternative Name) certificate fields would be used.
- But the self-signed certificates usually only contain the CN field without SAN so YaST could not connect to SMT/RMT
registration servers.
- This error prevented from importing the SSL certificate (that's enabled only for specific known errors): ![cert_cn_problem](https://user-images.githubusercontent.com/907998/152821265-6ec7b800-0c5f-4021-ad84-98cf7e3925ec.png)


## Test

- Tested manually, the certificate can be now imported: ![cert_cn_fixed](https://user-images.githubusercontent.com/907998/152821365-d175f272-16ce-4ad2-a3d7-754e280c1bc1.png)

## Notes

- Originally I wanted to fix that in `yast2-registration` but it turned out that Go reads the setting only at startup, changing the environment variable later does not have any effect.
- During installation the registration code might be loaded early in the self-update code, we need to be sure it is set before loading `suseconnect-ng` from anywhere.
- It needs to be set also in installed system so it cannot be fixed in `yast2-installation` starting scrips.
- See also related fix https://github.com/SUSE/connect-ng/pull/118