### PR TITLE
Support managing system in a chroot (bsc#1199840)

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Tue May 24 08:37:42 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added experimental infrastructure for managing system in
+  a chroot (bsc#1199840)
+- 4.5.1
+
+-------------------------------------------------------------------
 Wed Apr 06 13:24:58 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.5.0 (bsc#1198109)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.5.0
+Version:        4.5.1
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -114,6 +114,16 @@ module Yast
       left_title + architecture.rjust(78-left_title.size)
     end
 
+    # Open a new SCR instance with chroot
+    #
+    # @param target [String] the chroot target location
+    # @return [Integer] the original SCR handle
+    def self.redirect_scr(target)
+      old_handle = Yast::WFM.SCRGetDefault
+      handle = Yast::WFM.SCROpen("chroot=#{target}:scr", false)
+      Yast::WFM.SCRSetDefault(handle)
+      old_handle
+    end
 
     # client returned special result, this is used as offset (or as generic error)
     RES_CLIENT_RESULT = 16

--- a/src/ruby/yast/y2start_helpers.rb
+++ b/src/ruby/yast/y2start_helpers.rb
@@ -1,3 +1,6 @@
+
+require "yast"
+
 module Yast
   module Y2StartHelpers
     # Configure global environment for YaST

--- a/src/y2start/y2start
+++ b/src/y2start/y2start
@@ -55,6 +55,14 @@ set_title = args[:client_options][:params].empty? || NO_CLI_CLIENTS.include?(arg
 Yast::UI.SetApplicationTitle(
   Yast::Y2StartHelpers.application_title(args[:client_name])) if set_title
 
+target_dir = ENV["YAST_SCR_TARGET"] || ""
+if !target_dir.empty? && target_dir != "/"
+  if File.directory?(target_dir)
+    Yast::Y2StartHelpers.redirect_scr(target_dir)
+  else
+    abort "Cannot set the target, directory #{target_dir} not found"
+  end
+end
 
 exit Yast::Y2StartHelpers.generate_exit_code(
   Yast::WFM.CallFunction(args[:client_name], args[:client_options][:params])

--- a/tests/y2start_helpers_spec.rb
+++ b/tests/y2start_helpers_spec.rb
@@ -2,6 +2,7 @@
 # encoding: utf-8
 
 require_relative "test_helper"
+require "yast"
 require "yast/y2start_helpers"
 
 describe Yast::Y2StartHelpers do
@@ -135,6 +136,20 @@ describe Yast::Y2StartHelpers do
     it "returns 16+number for number" do
       expect(subject.generate_exit_code(1)).to eq 17
       expect(subject.generate_exit_code(3)).to eq 19
+    end
+  end
+
+  describe ".redirect_scr" do
+    it "opens a new SCR with chroot option" do
+      target = "/mnt"
+      handle = 42
+
+      allow(Yast::WFM).to receive(:SCRGetDefault)
+      expect(Yast::WFM).to receive(:SCROpen).with("chroot=#{target}:scr", false)
+        .and_return(handle)
+      expect(Yast::WFM).to receive(:SCRSetDefault).with(handle)
+
+      subject.redirect_scr(target)
     end
   end
 end

--- a/tests/y2start_helpers_spec.rb
+++ b/tests/y2start_helpers_spec.rb
@@ -2,7 +2,6 @@
 # encoding: utf-8
 
 require_relative "test_helper"
-require "yast"
 require "yast/y2start_helpers"
 
 describe Yast::Y2StartHelpers do


### PR DESCRIPTION
## Problem

When running YaST in a container we need to somehow detect that YaST should manage the system mounted in the /mnt and not the container itself.

- Lets use `YAST_SCR_TARGET` environment variable for that

## Solution

- Initialize SCR in the target chroot when starting YaST
- See related https://github.com/yast/yast-yast2/pull/1258


