### PR TITLE
Fix build

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Thu Aug 18 08:07:00 UTC 2022 - Josef Reidinger <jreidinger@suse.com>
+
+- Add properly glibc-locale as build dependency to test locale
+  dependent methods (related to change for bsc#1154405)
+- 4.5.2
+
+-------------------------------------------------------------------
 Tue May 24 08:37:42 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
 
 - Added experimental infrastructure for managing system in

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.5.1
+Version:        4.5.2
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -37,6 +37,9 @@ BuildRequires:  yast2-core-devel >= 3.2.2
 # MenuBar-shortcuts-test.rb
 Requires:       yast2-ycp-ui-bindings       >= 4.3.7
 BuildRequires:  yast2-ycp-ui-bindings-devel >= 4.3.7
+# requirement for testing locale dependent methods.
+# Keep it only build requirement to not force installation of this package everywhere
+BuildRequires:  glibc-locale
 %ifarch s390 s390x
 # s390 specific frame title that is read from readvalues from s390-tools
 # needed also for tests, so build require it


### PR DESCRIPTION
## Problem

Build failing with failure in test suite that verify locale dependent methods.

- this PR breaks it https://github.com/libyui/libyui/pull/77


## Solution

add build dependency for glibc-locale to always have it available as previously it is drag in by libyui.


## Testing

- *Tested manually*
