### PR TITLE
Added "log.group" method, allow installation via "yupdate"

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,16 @@
 require "yast/rake"
+require "rbconfig"
 
 Yast::Tasks.configuration do |conf|
   # lets ignore license check for now
   conf.skip_license_check << /.*/
+
+  # support installation via "yupdate" script in the inst-sys,
+  # we can only install the Ruby scripts because the C compiler and the development
+  # files are missing in the inst-sys, but this might be enough in some cases...
+  # this replicates the tasks from src/CMakeLists.txt
+  conf.install_locations["src/y2start/y2start"] = File.join(Packaging::Configuration::YAST_LIB_DIR, "bin")
+  vendor_dir = File.join(Packaging::Configuration::DESTDIR, RbConfig::CONFIG["vendorlibdir"])
+  conf.install_locations["src/ruby/yast.rb"] = vendor_dir
+  conf.install_locations["src/ruby/yast"] = vendor_dir
 end

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,13 @@
 -------------------------------------------------------------------
+Mon Oct 24 12:51:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>
+
+- Added "log.group" method for grouping the log messages
+  (bsc#1204625)
+- Update Rakefile to allow installing the Ruby files in inst-sys
+  using the "yupdate" command
+- 4.5.4
+
+-------------------------------------------------------------------
 Thu Oct  6 14:26:41 UTC 2022 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Dropped support for profiler / Y2PROFILER env var (bsc#1189647)


### PR DESCRIPTION
## Problem

- https://bugzilla.suse.com/show_bug.cgi?id=1204625
- In short: YaST should allow log grouping similar to [GitHub log grouping](https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#grouping-log-lines)

## Solution

Added new `log.group` method, see the [example log from TW installation](https://lslezak.github.io/ylogviewer/?log_url=https%3A%2F%2Fgist.githubusercontent.com%2Flslezak%2Fd36a2a15b9ccd49f035c7e51b4818ee5%2Fraw%2Fa8f2822f608f7ae0bbabb3dbe457b5202e21da25%2Fy2log-tw-installation.tar.xz) how it will work (click the "Load URL" button to load the example log).

```ruby
log.group "Description of the group" do
  foo
end
```

This logs special begin and end marks to the y2log, these might be used when reading/displaying the log.

It returns the block return value, it can be easily used like

```ruby
# returns the `bar` value
def foo
  log.group "Description of the group" do
    bar
  end
end
```

Optionally you can describe also the result

```ruby
  log.group "Description" do |group|
    ret = bar
    group.summary "Installed {ret} packages"
    ret
  end
```

The code automatically treats values `:abort`, `:cancel` and `false` as failures. But you can explicitly mark a failure

```ruby
  log.group "Description" do |group|
    ret = bar
    group.failed = true if ret == 0
    ret
  end
```
### `yupdate` Support

The `Rakefile` was updated so the Ruby files can be easily updated in the inst-sys with the `yupdate` command.

## Testing

- Added a new unit test
- Tested manually, see an [example log from TW installation](https://lslezak.github.io/ylogviewer/?log_url=https%3A%2F%2Fgist.githubusercontent.com%2Flslezak%2Fd36a2a15b9ccd49f035c7e51b4818ee5%2Fraw%2Fa8f2822f608f7ae0bbabb3dbe457b5202e21da25%2Fy2log-tw-installation.tar.xz) (click the "Load URL" button to load the example log)



