### PR TITLE
Default ruby is older

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Thu Mar  9 10:36:23 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Use ruby-devel versioned to match the gems (bsc#1209098)
+- 4.6.1
+
+-------------------------------------------------------------------
 Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
 
 - Bump version to 4.6.0 (bsc#1208913)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.6.0
+Version:        4.6.1
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -31,7 +31,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 Requires:       rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
-BuildRequires:  ruby-devel
+# this is ruby-devel pinned to the default version, matching the gems
+BuildRequires:  %{rubydevel}
 Requires:       yast2-core >= 3.2.2
 BuildRequires:  yast2-core-devel >= 3.2.2
 # MenuBar-shortcuts-test.rb


### PR DESCRIPTION
## Problem

Build failure in IBS

- https://build.suse.de/package/live_build_log/Devel:YaST:Head/yast2-ruby-bindings/SUSE_Factory_Head/x86_64
- https://bugzilla.suse.com/show_bug.cgi?id=1209098

## Solution

Fix dependency versioning

## Testing

Tested building in OBS (3.2) and IBS (3.1)

## Screenshots

N/A
