### PR TITLE
Optimize memory used by the `publish` calls

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Mon Apr  3 10:46:37 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Improve YaST memory consumption (bsc#1210051)
+- 4.6.2
+
+-------------------------------------------------------------------
 Thu Mar  9 10:36:23 UTC 2023 - Martin Vidner <mvidner@suse.com>
 
 - Use ruby-devel versioned to match the gems (bsc#1209098)

--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,7 +1,7 @@
 -------------------------------------------------------------------
 Mon Apr  3 10:46:37 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
-- Improve YaST memory consumption (bsc#1210051)
+- Improve YaST memory consumption related to import+publish (bsc#1210051)
 - 4.6.2
 
 -------------------------------------------------------------------

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.6.1
+Version:        4.6.2
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/profiling/yast_import.rb
+++ b/profiling/yast_import.rb
@@ -1,0 +1,10 @@
+require "memory_profiler"
+
+MemoryProfiler.report {
+  require "yast"
+
+  Yast.import "Pkg"
+  Yast.import "Bootloader"
+  Yast.import "UI"
+  Yast.import "Lan"
+}.pretty_print

--- a/profiling/yast_import.rb
+++ b/profiling/yast_import.rb
@@ -1,5 +1,13 @@
 require "memory_profiler"
 
+usage = <<CMD
+cd build # cmake ..; make
+# use the built version
+ruby -r ../tests/test_helper.rb ../profiling/yast_import.rb  # | head -n2
+# use the system version
+ruby                            ../profiling/yast_import.rb  # | head -n2
+CMD
+
 MemoryProfiler.report {
   require "yast"
 

--- a/src/binary/YRubyNamespace.cc
+++ b/src/binary/YRubyNamespace.cc
@@ -274,15 +274,12 @@ VALUE YRubyNamespace::getRubyModule()
 int YRubyNamespace::addMethods(VALUE module)
 {
   VALUE methods = rb_funcall(module, rb_intern("published_functions"),0);
-  methods = rb_funcall(methods,rb_intern("values"),0);
   int j = 0;
   for (int i = 0; i < RARRAY_LEN(methods); ++i)
   {
-    VALUE method = rb_ary_entry(methods,i);
-    if (getenv("Y2ALLGLOBAL") == NULL && RTEST(rb_funcall(method, rb_intern("private?"), 0)))
-      continue;
-    VALUE method_name = rb_funcall(method, rb_intern("function"), 0);
-    VALUE type = rb_funcall(method,rb_intern("type"),0);
+    VALUE method = rb_ary_entry(methods, i);
+    VALUE method_name = rb_hash_aref(method, rb_intern("name"));
+    VALUE type = rb_hash_aref(method, rb_intern("type"));
     string signature = StringValueCStr(type);
 
     addMethod(rb_id2name(SYM2ID(method_name)), signature, j++);
@@ -293,18 +290,12 @@ int YRubyNamespace::addMethods(VALUE module)
 int YRubyNamespace::addVariables(VALUE module, int offset)
 {
   VALUE variables = rb_funcall(module, rb_intern("published_variables"),0);
-  variables = rb_funcall(variables,rb_intern("values"),0);
   int j=0;
   for (int i = 0; i < RARRAY_LEN(variables); ++i)
   {
-    VALUE variable = rb_ary_entry(variables,i);
-    VALUE variable_name = rb_funcall(variable, rb_intern("variable"), 0);
-    if (getenv("Y2ALLGLOBAL") == NULL && RTEST(rb_funcall(variable, rb_intern("private?"), 0)))
-    {
-      y2debug("variable: '%s' is private and not needed", rb_id2name(SYM2ID(variable_name)));
-      continue;
-    }
-    VALUE type = rb_funcall(variable,rb_intern("type"),0);
+    VALUE variable = rb_ary_entry(variables, i);
+    VALUE variable_name = rb_hash_aref(variable, rb_intern("name"));
+    VALUE type = rb_hash_aref(variable, rb_intern("type"));
     string signature = StringValueCStr(type);
     constTypePtr sym_tp = Type::fromSignature(signature);
 

--- a/src/binary/YRubyNamespace.cc
+++ b/src/binary/YRubyNamespace.cc
@@ -278,8 +278,8 @@ int YRubyNamespace::addMethods(VALUE module)
   for (int i = 0; i < RARRAY_LEN(methods); ++i)
   {
     VALUE method = rb_ary_entry(methods, i);
-    VALUE method_name = rb_hash_aref(method, rb_intern("name"));
-    VALUE type = rb_hash_aref(method, rb_intern("type"));
+    VALUE method_name = rb_hash_aref(method, ID2SYM(rb_intern("name")));
+    VALUE type = rb_hash_aref(method, ID2SYM(rb_intern("type")));
     string signature = StringValueCStr(type);
 
     addMethod(rb_id2name(SYM2ID(method_name)), signature, j++);
@@ -294,8 +294,8 @@ int YRubyNamespace::addVariables(VALUE module, int offset)
   for (int i = 0; i < RARRAY_LEN(variables); ++i)
   {
     VALUE variable = rb_ary_entry(variables, i);
-    VALUE variable_name = rb_hash_aref(variable, rb_intern("name"));
-    VALUE type = rb_hash_aref(variable, rb_intern("type"));
+    VALUE variable_name = rb_hash_aref(variable, ID2SYM(rb_intern("name")));
+    VALUE type = rb_hash_aref(variable, ID2SYM(rb_intern("type")));
     string signature = StringValueCStr(type);
     constTypePtr sym_tp = Type::fromSignature(signature);
 

--- a/src/binary/YRubyNamespace.cc
+++ b/src/binary/YRubyNamespace.cc
@@ -36,6 +36,14 @@ as published by the Free Software Foundation; either version
 #include "YRuby.h"
 #include "Y2RubyUtils.h"
 
+
+// HELPER method to inspect ruby values from C++. Useful for debugging
+static void log_inspect(const char * message, VALUE v)
+{
+  VALUE inspect = rb_funcall(v, rb_intern("inspect"), 0);
+  y2internal("%s: %s", message, StringValueCStr(inspect));
+}
+
 /**
  * Exception raised when type signature in ruby class is invalid
  */

--- a/src/binary/YRubyNamespace.cc
+++ b/src/binary/YRubyNamespace.cc
@@ -38,11 +38,14 @@ as published by the Free Software Foundation; either version
 
 
 // HELPER method to inspect ruby values from C++. Useful for debugging
+/*
+// usage: log_inspect("surely not nil, foobar", foobar);
 static void log_inspect(const char * message, VALUE v)
 {
   VALUE inspect = rb_funcall(v, rb_intern("inspect"), 0);
   y2internal("%s: %s", message, StringValueCStr(inspect));
 }
+*/
 
 /**
  * Exception raised when type signature in ruby class is invalid

--- a/src/binary/YRubyNamespace.cc
+++ b/src/binary/YRubyNamespace.cc
@@ -286,8 +286,8 @@ int YRubyNamespace::addMethods(VALUE module)
   for (int i = 0; i < RARRAY_LEN(methods); ++i)
   {
     VALUE method = rb_ary_entry(methods, i);
-    VALUE method_name = rb_hash_aref(method, ID2SYM(rb_intern("name")));
-    VALUE type = rb_hash_aref(method, ID2SYM(rb_intern("type")));
+    VALUE method_name = rb_ary_entry(method, 0);
+    VALUE type = rb_ary_entry(method, 1);
     string signature = StringValueCStr(type);
 
     addMethod(rb_id2name(SYM2ID(method_name)), signature, j++);
@@ -302,8 +302,8 @@ int YRubyNamespace::addVariables(VALUE module, int offset)
   for (int i = 0; i < RARRAY_LEN(variables); ++i)
   {
     VALUE variable = rb_ary_entry(variables, i);
-    VALUE variable_name = rb_hash_aref(variable, ID2SYM(rb_intern("name")));
-    VALUE type = rb_hash_aref(variable, ID2SYM(rb_intern("type")));
+    VALUE variable_name = rb_ary_entry(variable, 0);
+    VALUE type = rb_ary_entry(variable, 1);
     string signature = StringValueCStr(type);
     constTypePtr sym_tp = Type::fromSignature(signature);
 

--- a/src/ruby/yast/exportable.rb
+++ b/src/ruby/yast/exportable.rb
@@ -4,12 +4,24 @@ module Yast
   # Provides ability to export functions and variables to Yast component system.
   # The most important method is {Yast::Exportable#publish}
   module Exportable
-    # list of published functions
+    # @api private
+    # @return [Array<Array(Symbol,String)>] list of published functions
+    # @example
+    #   [
+    #     [:doit, "void()"],
+    #     [:is_odd, "boolean(integer)"]
+    #   ]
     def published_functions
       @__published_functions ||= []
     end
 
-    # list of published variables
+    # @api private
+    # @return [Array<Array(Symbol,String)>] list of published variables
+    # @example
+    #   [
+    #     [:answer, "integer"],
+    #     [:having_fun, "boolean"]
+    #   ]
     def published_variables
       @__published_variables ||= []
     end
@@ -30,9 +42,9 @@ module Yast
       type.gsub!(/map([^<]|$)/, 'map<any,any>\\1')
       type.gsub!(/list([^<]|$)/, 'list<any>\\1')
       if options[:function]
-        published_functions.push({ name: options[:function], type: type })
+        published_functions.push([options[:function], type])
       elsif options[:variable]
-        published_variables.push({ name: options[:variable], type: type })
+        published_variables.push([options[:variable], type])
         attr_accessor options[:variable]
       else
         raise "Missing publish kind"

--- a/src/ruby/yast/exportable.rb
+++ b/src/ruby/yast/exportable.rb
@@ -4,24 +4,14 @@ module Yast
   # Provides ability to export functions and variables to Yast component system.
   # The most important method is {Yast::Exportable#publish}
   module Exportable
-    # Holder for exported data
-    class ExportData < OpenStruct
-      # Is exported data only for private purpose.
-      # It is useful only to test private methods from old Yast testsuite.
-      def private?
-        table = marshal_dump
-        !!table[:private]
-      end
-    end
-
     # list of published functions
     def published_functions
-      @__published_functions ||= {}
+      @__published_functions ||= []
     end
 
     # list of published variables
     def published_variables
-      @__published_variables ||= {}
+      @__published_variables ||= []
     end
 
     # Publishes function or variable to component system
@@ -37,16 +27,13 @@ module Yast
       raise "Missing signature" unless options[:type]
       # convert type to full specification
       type = options[:type].delete " \t"
-      type = type.gsub(/map([^<]|$)/, 'map<any,any>\\1')
-      type = type.gsub(/list([^<]|$)/, 'list<any>\\1')
-      options[:type] = type
+      type.gsub!(/map([^<]|$)/, 'map<any,any>\\1')
+      type.gsub!(/list([^<]|$)/, 'list<any>\\1')
       if options[:function]
-        published_functions[options[:function]] = ExportData.new options
+        published_functions.push({ name: options[:function], type: type })
       elsif options[:variable]
-        published_variables[options[:variable]] = ExportData.new options
-        if !options[:private] || ENV["Y2ALLGLOBAL"]
-          attr_accessor :"#{options[:variable]}"
-        end
+        published_variables.push({ name: options[:variable], type: type })
+        attr_accessor options[:variable]
       else
         raise "Missing publish kind"
       end

--- a/src/ruby/yast/path.rb
+++ b/src/ruby/yast/path.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Yast
   # Represents paths like it is in ycp. It is path elements separated by dot.
   # Elements can be simple or complex. Simple can contain only ascii characters [a-zA-Z0-9].
@@ -71,7 +72,7 @@ module Yast
     def load_components(value)
       state = :initial
       skip_next = false
-      buffer = ""
+      buffer = "".dup
       value.each_char do |c|
         case state
         when :initial
@@ -91,7 +92,7 @@ module Yast
             raise "Invalid path '#{value}'" if invalid_buffer?(buffer)
 
             @components << modify_buffer(buffer)
-            buffer = ""
+            buffer = "".dup
             next
           end
           buffer << c
@@ -107,7 +108,7 @@ module Yast
             state = :initial
             buffer << c
             @components << buffer
-            buffer = ""
+            buffer = "".dup
             next
           when '\\'
             skip_next = true

--- a/src/ruby/yast/yast.rb
+++ b/src/ruby/yast/yast.rb
@@ -179,7 +179,7 @@ module Yast
     # do not reimport if already imported and contain some methods
     # ( in case namespace contain some methods )
     if base.constants.include?(modules.last.to_sym) &&
-        !(base.const_get(modules.last).methods - Object.methods).empty?
+        !base.const_get(modules.last).public_methods(false).empty?
       return
     end
 
@@ -187,7 +187,7 @@ module Yast
 
     # do not create wrapper if module is in ruby and define itself object
     if base.constants.include?(modules.last.to_sym) &&
-        !(base.const_get(modules.last).methods - Object.methods).empty?
+        !base.const_get(modules.last).public_methods(false).empty?
       return
     end
 

--- a/tests/exportable_spec.rb
+++ b/tests/exportable_spec.rb
@@ -27,22 +27,18 @@ MyTest = MyTestClass.new
 
 describe "ExportableTest" do
   it "tests publish methods" do
-    expect(MyTest.class.published_functions.keys).to eq([:test])
-    expect(MyTest.class.published_functions.values.first.function).to eq(:test)
-    expect(MyTest.class.published_functions[:test].type).to eq("string(integer,term)")
+    expect(MyTest.class.published_functions).to eq([{name: :test, type: "string(integer,term)"}])
   end
 
   it "tests publish variables" do
-    expect(MyTest.class.published_variables[:variable_a].type).to eq("map<any,any>")
+    expect(MyTest.class.published_variables).to match_array([
+      {name: :variable_a, type: "map<any,any>"},
+      {name: :complex, type: "map<string,map<list<any>,map<any,any>>>"}
+    ])
   end
 
   it "tests variable definition" do
     MyTest.variable_a = ({ a: 15 })
     expect(MyTest.variable_a).to eq(a: 15)
-  end
-
-  it "tests type full specification" do
-    expect(MyTest.class.published_variables[:complex].type)
-      .to eq("map<string,map<list<any>,map<any,any>>>")
   end
 end

--- a/tests/exportable_spec.rb
+++ b/tests/exportable_spec.rb
@@ -27,13 +27,15 @@ MyTest = MyTestClass.new
 
 describe "ExportableTest" do
   it "tests publish methods" do
-    expect(MyTest.class.published_functions).to eq([{name: :test, type: "string(integer,term)"}])
+    expect(MyTest.class.published_functions).to eq([
+      [:test, "string(integer,term)"]
+    ])
   end
 
   it "tests publish variables" do
-    expect(MyTest.class.published_variables).to match_array([
-      {name: :variable_a, type: "map<any,any>"},
-      {name: :complex, type: "map<string,map<list<any>,map<any,any>>>"}
+    expect(MyTest.class.published_variables).to eq([
+      [:complex, "map<string,map<list<any>,map<any,any>>>"],
+      [:variable_a, "map<any,any>"]
     ])
   end
 

--- a/tests/test_module/modules/InvalidTypeModule.rb
+++ b/tests/test_module/modules/InvalidTypeModule.rb
@@ -1,5 +1,7 @@
 module Yast
   class InvalidTypeModuleClass < Module
+    include Yast::Logger
+
     def a
       puts "Fail"
     end


### PR DESCRIPTION
## Problem

Agame and also yast consume quite bit of memory, so lets try to optimize it.


## Solution

Add some profiling code and based on it, apply some optimization.

Optimization results ( testing on Leap15.4 so with ruby 2.5 ) just totals:

Original result:

```
Total allocated: 33846260 bytes (365250 objects)
Total retained:  5387014 bytes (47980 objects)
```

after first optimization:

```
Total allocated: 32843452 bytes (364422 objects)
Total retained:  5383110 bytes (47979 objects)
```

after second optimization:

```
Total allocated: 31132062 bytes (351286 objects)
Total retained:  4337427 bytes (41452 objects)
```

So result is roughly saved **2650 KiB** of allocated and in persistent it is **1021 KiB** on testing  sample that just require yast and imports some yast modules.