### PR TITLE
Backport sp6

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,7 +1,19 @@
 -------------------------------------------------------------------
-Fri Sep 01 19:57:03 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+Mon Apr  3 10:46:37 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
 
-- Branch package for SP6 (bsc#1208913)
+- Improve YaST memory consumption related to import+publish (bsc#1210051)
+- 4.6.2
+
+-------------------------------------------------------------------
+Thu Mar  9 10:36:23 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Use ruby-devel versioned to match the gems (bsc#1209098)
+- 4.6.1
+
+-------------------------------------------------------------------
+Fri Mar 03 14:44:07 UTC 2023 - Ladislav Slezák <lslezak@suse.cz>
+
+- Bump version to 4.6.0 (bsc#1208913)
 
 -------------------------------------------------------------------
 Mon Oct 24 12:51:30 UTC 2022 - Ladislav Slezák <lslezak@suse.cz>

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        4.6.0
+Version:        4.6.2
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build
@@ -31,7 +31,8 @@ BuildRequires:  yast2-devtools >= 3.1.10
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
 BuildRequires:  rubygem(%{rb_default_ruby_abi}:rspec)
 Requires:       rubygem(%{rb_default_ruby_abi}:fast_gettext) < 3.0
-BuildRequires:  ruby-devel
+# this is ruby-devel pinned to the default version, matching the gems
+BuildRequires:  %{rubydevel}
 Requires:       yast2-core >= 3.2.2
 BuildRequires:  yast2-core-devel >= 3.2.2
 # MenuBar-shortcuts-test.rb

--- a/profiling/yast_import.rb
+++ b/profiling/yast_import.rb
@@ -1,0 +1,18 @@
+require "memory_profiler"
+
+usage = <<CMD
+cd build # cmake ..; make
+# use the built version
+ruby -r ../tests/test_helper.rb ../profiling/yast_import.rb  # | head -n2
+# use the system version
+ruby                            ../profiling/yast_import.rb  # | head -n2
+CMD
+
+MemoryProfiler.report {
+  require "yast"
+
+  Yast.import "Pkg"
+  Yast.import "Bootloader"
+  Yast.import "UI"
+  Yast.import "Lan"
+}.pretty_print

--- a/src/ruby/yast/path.rb
+++ b/src/ruby/yast/path.rb
@@ -1,3 +1,4 @@
+# frozen_string_literal: true
 module Yast
   # Represents paths like it is in ycp. It is path elements separated by dot.
   # Elements can be simple or complex. Simple can contain only ascii characters [a-zA-Z0-9].
@@ -71,7 +72,7 @@ module Yast
     def load_components(value)
       state = :initial
       skip_next = false
-      buffer = ""
+      buffer = "".dup
       value.each_char do |c|
         case state
         when :initial
@@ -91,7 +92,7 @@ module Yast
             raise "Invalid path '#{value}'" if invalid_buffer?(buffer)
 
             @components << modify_buffer(buffer)
-            buffer = ""
+            buffer = "".dup
             next
           end
           buffer << c
@@ -107,7 +108,7 @@ module Yast
             state = :initial
             buffer << c
             @components << buffer
-            buffer = ""
+            buffer = "".dup
             next
           when '\\'
             skip_next = true

--- a/src/ruby/yast/yast.rb
+++ b/src/ruby/yast/yast.rb
@@ -179,7 +179,7 @@ module Yast
     # do not reimport if already imported and contain some methods
     # ( in case namespace contain some methods )
     if base.constants.include?(modules.last.to_sym) &&
-        !(base.const_get(modules.last).methods - Object.methods).empty?
+        !base.const_get(modules.last).public_methods(false).empty?
       return
     end
 
@@ -187,7 +187,7 @@ module Yast
 
     # do not create wrapper if module is in ruby and define itself object
     if base.constants.include?(modules.last.to_sym) &&
-        !(base.const_get(modules.last).methods - Object.methods).empty?
+        !base.const_get(modules.last).public_methods(false).empty?
       return
     end
 

--- a/tests/exportable_spec.rb
+++ b/tests/exportable_spec.rb
@@ -27,22 +27,20 @@ MyTest = MyTestClass.new
 
 describe "ExportableTest" do
   it "tests publish methods" do
-    expect(MyTest.class.published_functions.keys).to eq([:test])
-    expect(MyTest.class.published_functions.values.first.function).to eq(:test)
-    expect(MyTest.class.published_functions[:test].type).to eq("string(integer,term)")
+    expect(MyTest.class.published_functions).to eq([
+      [:test, "string(integer,term)"]
+    ])
   end
 
   it "tests publish variables" do
-    expect(MyTest.class.published_variables[:variable_a].type).to eq("map<any,any>")
+    expect(MyTest.class.published_variables).to eq([
+      [:complex, "map<string,map<list<any>,map<any,any>>>"],
+      [:variable_a, "map<any,any>"]
+    ])
   end
 
   it "tests variable definition" do
     MyTest.variable_a = ({ a: 15 })
     expect(MyTest.variable_a).to eq(a: 15)
-  end
-
-  it "tests type full specification" do
-    expect(MyTest.class.published_variables[:complex].type)
-      .to eq("map<string,map<list<any>,map<any,any>>>")
   end
 end

--- a/tests/test_module/modules/InvalidTypeModule.rb
+++ b/tests/test_module/modules/InvalidTypeModule.rb
@@ -1,5 +1,7 @@
 module Yast
   class InvalidTypeModuleClass < Module
+    include Yast::Logger
+
     def a
       puts "Fail"
     end


### PR DESCRIPTION
## Problem

SLE 15 SP6 branch is based on SLE15 SP5 maintenance branch. So fixes done in master can be sometimes useful also for SP6.


## Solution

Backport both fixes (#288 and #289) , so it is same as 4.6.2.