### PR TITLE
Adapt code to ruby 3.4

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Fri Dec 20 16:01:56 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
+
+- Adapt to ruby 3.4 (gh#yast/yast-ruby-bindings#292)
+- 5.0.1
+
+-------------------------------------------------------------------
 Wed Aug 30 20:16:10 UTC 2023 - Josef Reidinger <jreidinger@suse.cz>
 
 - 5.0.0 (bsc#1185510)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        5.0.0
+Version:        5.0.1
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/ruby/yast/logger.rb
+++ b/src/ruby/yast/logger.rb
@@ -34,7 +34,7 @@ module Yast
 
     res = Builtins.sformat(*safe_args)
     res.gsub!(/%/, "%%") # reescape all %
-    matches = caller(caller_frame + 1, 1).first.match(/(.+):(\d+):in `([^']+)'/)
+    matches = caller(caller_frame + 1, 1).first.match(/(.+):(\d+):in [`']([^']+)'/)
     y2_logger(level, "Ruby", matches[1], matches[2].to_i, matches[3], res)
 
     return unless backtrace

--- a/src/ruby/yast/yast.rb
+++ b/src/ruby/yast/yast.rb
@@ -16,7 +16,7 @@ module Yast
   end
 
   # @private used to extract place from backtrace
-  BACKTRACE_REGEXP = /^(.*):(\d+):in `.*'$/
+  BACKTRACE_REGEXP = /^(.*):(\d+):in [`'].*'$/
 
   # shortcut to construct new Yast term
   # @see Yast::Term


### PR DESCRIPTION
## Problem

In ruby 3.4 backtrace format changed and yast2-ruby-bindings rely on it.

## Solution

Fix the code to work with both older and newer ruby.


## Testing

- already covered by existing tests. I run with new ruby in staging:L
