### PR TITLE
disable libyui integration tests in ruby-bindings as it is not reliable

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,11 @@
 -------------------------------------------------------------------
+Wed Jan 15 08:39:02 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
+
+- Disable integration tests with libyui
+  (gh#yast/yast-ruby-bindings#293)
+- 5.0.2
+
+-------------------------------------------------------------------
 Fri Dec 20 16:01:56 UTC 2024 - Josef Reidinger <jreidinger@suse.com>
 
 - Adapt to ruby 3.4 (gh#yast/yast-ruby-bindings#292)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -48,14 +48,6 @@ BuildRequires:  s390-tools
 Requires:       s390-tools
 %endif
 
-
-# The test suite includes a regression test (std_streams_spec.rb) for a
-# libyui-ncurses bug fixed in 2.47.3
-BuildRequires:  libyui-ncurses >= 2.47.3
-# The mentioned test requires tmux in order to be executed in headless systems
-# Also many other libyui tests to come
-BuildRequires:  tmux
-
 # only a soft dependency, the Ruby debugger is optional
 Suggests:       rubygem(%{rb_default_ruby_abi}:byebug)
 
@@ -96,9 +88,6 @@ make install DESTDIR=$RPM_BUILD_ROOT
 cd -
 
 %check
-# Build workers are set up without systemd so the default /run/tmux dir
-# will not be present (unless clamav pulls systemd in, on SLE)
-export TMUX_TMPDIR=/tmp
 cd build
 make test ARGS=-V
 cd -

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        5.0.1
+Version:        5.0.2
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -19,7 +19,9 @@ endforeach(test)
 # ADD_TEST("integration"  ruby ${CMAKE_CURRENT_SOURCE_DIR}/integration/run.rb)
 ADD_TEST("translations" rspec --format doc ${CMAKE_CURRENT_SOURCE_DIR}/integration/translations_spec.rb)
 
-file(GLOB libyui_specs "libyui/*_spec.rb")
-foreach(test ${libyui_specs})
-    ADD_TEST(${test}   rspec --format doc ${test})
-endforeach(test)
+# disable also libyui tests as it is too fragile on non intel architectures and it is not ruby-bindings job to test it
+# if wanted, it can live separately.
+# file(GLOB libyui_specs "libyui/*_spec.rb")
+# foreach(test ${libyui_specs})
+#    ADD_TEST(${test}   rspec --format doc ${test})
+# endforeach(test)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -15,7 +15,8 @@ foreach(test ${Specs})
     ADD_TEST(${test}   rspec --format doc ${test})
 endforeach(test)
 
-ADD_TEST("integration"  ruby ${CMAKE_CURRENT_SOURCE_DIR}/integration/run.rb)
+# disable integration test as it is too fragile on non intel architectures
+# ADD_TEST("integration"  ruby ${CMAKE_CURRENT_SOURCE_DIR}/integration/run.rb)
 ADD_TEST("translations" rspec --format doc ${CMAKE_CURRENT_SOURCE_DIR}/integration/translations_spec.rb)
 
 file(GLOB libyui_specs "libyui/*_spec.rb")

--- a/tests/integration/std_streams_spec.rb
+++ b/tests/integration/std_streams_spec.rb
@@ -14,7 +14,7 @@ Yast.import "UI"
 
 # Regression test for the fix of bnc#943757 implemented
 # in libyui-ncurses 2.47.3
-describe "streams redirection in libyui-ncurses" do
+xdescribe "streams redirection in libyui-ncurses" do
   include Yast::UIShortcuts
 
   around do |example|


### PR DESCRIPTION
## Problem

The integration test in yast2-ruby-bindings that test integration with libyui is quite fragile and often fails on non-intel architectures.


## Solution

disable tests for master as plan is to move away from libyui, so the drawbacks outweighs benefits.

