### PR TITLE
Use %make_build

### DIFF
--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -80,7 +80,7 @@ cmake -DCMAKE_INSTALL_PREFIX=%{prefix} \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_SKIP_RPATH=1 \
       ..
-make %{?jobs:-j %jobs} VERBOSE=1
+%make_build
 
 %install
 cd build


### PR DESCRIPTION
Use `%make_build`
instead of SUSE-specific `%jobs` macro,
because %jobs caused issues with reproducible builds (bsc#1237231).