### PR TITLE
Drop YaST Command Line Interface Support

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,10 @@
 -------------------------------------------------------------------
+Tue May 13 11:42:11 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Drop the YaST command line interface (CLI) (bsc#1243018)
+- 5.0.3
+
+-------------------------------------------------------------------
 Wed Jan 15 08:39:02 UTC 2025 - Josef Reidinger <jreidinger@suse.com>
 
 - Disable integration tests with libyui

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        5.0.2
+Version:        5.0.3
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/y2start/y2start
+++ b/src/y2start/y2start
@@ -45,15 +45,24 @@ if !Yast::WFM.ClientExists(args[:client_name])
 end
 
 NO_CLI_CLIENTS = ["installation", "view_anymsg", "firstboot", "scc"].freeze
+cli_mode = !args[:client_options][:params].empty? && !NO_CLI_CLIENTS.include?(args[:client_name])
+
+if cli_mode
+  # bsc#1243018: Drop yast-cli mode
+  msg = "FATAL: The YaST command line interface is not supported anymore. Exiting.".freeze
+  Yast.y2error(msg)
+  warn(msg)
+  exit(1)
+end
+
 Yast.ui_create(args[:server_name], args[:server_options])
 # set application title bsc#1033161
 Yast.import "UI"
 
 # set title only if it is not CLI (bsc#1033993)
 # modules do not have CLI arguments, except installation (bsc#1037891)
-set_title = args[:client_options][:params].empty? || NO_CLI_CLIENTS.include?(args[:client_name])
 Yast::UI.SetApplicationTitle(
-  Yast::Y2StartHelpers.application_title(args[:client_name])) if set_title
+  Yast::Y2StartHelpers.application_title(args[:client_name])) unless cli_mode
 
 target_dir = ENV["YAST_SCR_TARGET"] || ""
 if !target_dir.empty? && target_dir != "/"


### PR DESCRIPTION
## Bugzilla

https://bugzilla.suse.com/show_bug.cgi?id=1243018


## Problem / Motivation

YaST is only used as a library for the Agama backend in SLES-16 / Leap 16.

The functionality of YaST goes much further, but  we cannot guarantee that all the details and all the behavior in YaST are compatible in every detail with SLES-16 / Leap 16. This will create pitfalls for users who may find a way to still use YaST functionality that will then increasingly be outdated.

In long run, this will be true for Factory / Tumbleweed as well.

So we are starting to prevent pitfalls with this: The YaST command line  interface (CLI) should not be accessible anymore. This is even more important because this is an aspect of YaST that is less commonly used and thus less thoroughly tested.


## Fix

This PR makes the YaST  CLI unaccessible: When trying to use it, it will simply exit with an error message in the log and on stderr.

```console
sh@balrog:~> sudo yast2 lan list
FATAL: The YaST command line interface is not supported anymore. Exiting.
sh@balrog:~>
```

```console
sh@balrog:~> sudo yast2 lan
```
(-> The YaST lan module starts normally)


Some few YaST modules accept one command line argument for GUI operation, i.e. outside of the YaST CLI mode:

```console
sh@balrog:~> sudo yast2 view_anymsg /etc/os-release
```
(-> The YaST view_anymsg module opens a window showing the `/etc/os-release` file)