### PR TITLE
Revert #295: Drop YaST CLI

### DIFF
--- a/package/yast2-ruby-bindings.changes
+++ b/package/yast2-ruby-bindings.changes
@@ -1,4 +1,12 @@
 -------------------------------------------------------------------
+Wed May 28 11:44:30 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
+
+- Revert the last change (drop cli):
+  This caused build errors in other YaST packages.
+  (bsc##1243018)
+- 5.0.4
+
+-------------------------------------------------------------------
 Tue May 13 11:42:11 UTC 2025 - Stefan Hundhammer <shundhammer@suse.com>
 
 - Drop the YaST command line interface (CLI) (bsc#1243018)

--- a/package/yast2-ruby-bindings.spec
+++ b/package/yast2-ruby-bindings.spec
@@ -17,7 +17,7 @@
 
 
 Name:           yast2-ruby-bindings
-Version:        5.0.3
+Version:        5.0.4
 Release:        0
 URL:            https://github.com/yast/yast-ruby-bindings
 BuildRoot:      %{_tmppath}/%{name}-%{version}-build

--- a/src/y2start/y2start
+++ b/src/y2start/y2start
@@ -45,24 +45,15 @@ if !Yast::WFM.ClientExists(args[:client_name])
 end
 
 NO_CLI_CLIENTS = ["installation", "view_anymsg", "firstboot", "scc"].freeze
-cli_mode = !args[:client_options][:params].empty? && !NO_CLI_CLIENTS.include?(args[:client_name])
-
-if cli_mode
-  # bsc#1243018: Drop yast-cli mode
-  msg = "FATAL: The YaST command line interface is not supported anymore. Exiting.".freeze
-  Yast.y2error(msg)
-  warn(msg)
-  exit(1)
-end
-
 Yast.ui_create(args[:server_name], args[:server_options])
 # set application title bsc#1033161
 Yast.import "UI"
 
 # set title only if it is not CLI (bsc#1033993)
 # modules do not have CLI arguments, except installation (bsc#1037891)
+set_title = args[:client_options][:params].empty? || NO_CLI_CLIENTS.include?(args[:client_name])
 Yast::UI.SetApplicationTitle(
-  Yast::Y2StartHelpers.application_title(args[:client_name])) unless cli_mode
+  Yast::Y2StartHelpers.application_title(args[:client_name])) if set_title
 
 target_dir = ENV["YAST_SCR_TARGET"] || ""
 if !target_dir.empty? && target_dir != "/"


### PR DESCRIPTION
## Problem

The last PR #295 caused build problems in OBS for other YaST packages, so the SR for OBS Factory was rejected. This means that we now have different versions in YaST:Head and in openSUSE:Factory which is obviously bad.


## Cause

Some unit tests in other packages are checking the CLI, and with the CLI generally disabled those unit tests now failed which makes the whole build of that package fail.


## Fix

Revert that last PR.


## Alternative Approaches

- Go through all YaST packages one by one and check which ones have unit tests for the CLI and disable or remove those unit tests.

- Set up a build project with this patch and all other YaST packages and wait which ones fail and then disable or remove those unit tests.

Both approaches cause a lot of additional work; it is questionable if that is justified with regard to the expected remaining life time of YaST. And there is also the risk of breaking things in the process.